### PR TITLE
Serialization / Deserialization

### DIFF
--- a/src/Flux.js
+++ b/src/Flux.js
@@ -176,7 +176,7 @@ export default class Flux extends EventEmitter {
 
       let storeState = store.deserialize(serializedState);
 
-      store.state = storeState;
+      store.replaceState(storeState);
     }
   }
 

--- a/src/Flux.js
+++ b/src/Flux.js
@@ -15,14 +15,14 @@ export default class Flux extends EventEmitter {
 
   constructor() {
     this.dispatcher = new Dispatcher();
-    this._stores = new Map();
-    this._actions = new Map();
+    this._stores = {};
+    this._actions = {};
   }
 
   createStore(key, _Store, ...constructorArgs) {
 
     if (!(_Store.prototype instanceof Store) && _Store !== Store) {
-      let className = _Store.prototype.constructor.name;
+      let className = getClassName(_Store);
 
       throw new Error(
         `You've attempted to create a store from the class ${className}, which `
@@ -32,7 +32,7 @@ export default class Flux extends EventEmitter {
       );
     }
 
-    if (this._stores.has(key)) {
+    if (this._stores.hasOwnProperty(key) && this._stores[key]) {
       throw new Error(
         `You've attempted to create multiple stores with key ${key}. Keys must `
       + `be unique.`
@@ -45,21 +45,17 @@ export default class Flux extends EventEmitter {
     store._waitFor = this.waitFor.bind(this);
     store._token = token;
 
-    this._stores.set(key, store);
+    this._stores[key] = store;
   }
 
   getStore(key) {
-    return this._stores.get(key);
-  }
-
-  removeStore(key) {
-    this._stores.delete(key);
+    return this._stores.hasOwnProperty(key) ? this._stores[key] : undefined;
   }
 
   createActions(key, _Actions, ...constructorArgs) {
 
     if (!(_Actions.prototype instanceof Actions) && _Actions !== Actions) {
-      let className = _Actions.prototype.constructor.name;
+      let className = getClassName(_Actions);
 
       throw new Error(
         `You've attempted to create actions from the class ${className}, which `
@@ -69,7 +65,7 @@ export default class Flux extends EventEmitter {
       );
     }
 
-    if (this._actions.has(key)) {
+    if (this._actions.hasOwnProperty(key) && this._actions[key]) {
       throw new Error(
         `You've attempted to create multiple actions with key ${key}. Keys `
       + `must be unique.`
@@ -79,11 +75,11 @@ export default class Flux extends EventEmitter {
     let actions = new _Actions(...constructorArgs);
     actions.dispatch = this.dispatch.bind(this);
 
-    this._actions.set(key, actions);
+    this._actions[key] = actions;
   }
 
   getActions(key) {
-    return this._actions.get(key);
+    return this._actions.hasOwnProperty(key) ? this._actions[key] : undefined;
   }
 
   getActionIds(key) {
@@ -113,6 +109,83 @@ export default class Flux extends EventEmitter {
     this.dispatcher.waitFor(tokens);
   }
 
+  serialize() {
+    let stateTree = {};
+
+    for (let key in this._stores) {
+      if (!this._stores.hasOwnProperty(key)) continue;
+
+      let store = this._stores[key];
+
+      if (typeof store.serialize !== 'function') {
+        let className = store.constructor.name;
+
+        throw new Error(
+          `Cannot serialize Flux state because the store with key '${key}' `
+        + `does not have a \`serialize()\` method. Check the implementation of `
+        + `the ${className} class.`
+        );
+      }
+
+      let serializedStoreState = store.serialize();
+
+      if (typeof serializedStoreState !== 'string') {
+        let className = store.constructor.name;
+
+        throw new Error(
+          `\`Store#serialize()\ must return a string, but the store with key `
+        + `'${key}' returned a non-string with type `
+        + `'${typeof serializedStoreState}'. Check the \`#serialize()\ method `
+        + `of the ${className} class.`
+        );
+      }
+
+      stateTree[key] = store.serialize();
+    }
+
+    return JSON.stringify(stateTree);
+  }
+
+  deserialize(serializedState) {
+    try {
+      let state = JSON.parse(serializedState);
+    } catch (error) {
+      let className = this.constructor.name;
+
+      console.log(serializedState);
+
+      throw new Error(
+        `Invalid value passed to \`${className}#deserialize()\`. Ensure that `
+      + `each of your store's \`#serialize()\` methods returns a properly `
+      + `escaped string.`
+      );
+    }
+
+    for (let key in this._stores) {
+      if (!this._stores.hasOwnProperty(key)) continue;
+
+      let store = this._stores[key];
+
+      if (typeof store.deserialize !== 'function') {
+        let className = store.constructor.name;
+
+        throw new Error(
+          `Cannot deserialize Flux state because the store with key '${key}' `
+        + `does not have a \`deserialize()\` method. Check the implementation `
+        + `of the ${className} class.`
+        );
+      }
+
+      let storeState = store.deserialize(serializedState);
+
+      store.state = storeState;
+    }
+  }
+
+}
+
+function getClassName(Class) {
+  return Class.prototype.constructor.name;
 }
 
 let Flummox = Flux;

--- a/src/Flux.js
+++ b/src/Flux.js
@@ -152,8 +152,6 @@ export default class Flux extends EventEmitter {
     } catch (error) {
       let className = this.constructor.name;
 
-      console.log(serializedState);
-
       throw new Error(
         `Invalid value passed to \`${className}#deserialize()\`. Ensure that `
       + `each of your store's \`#serialize()\` methods returns a properly `

--- a/src/Store.js
+++ b/src/Store.js
@@ -3,7 +3,8 @@
  *
  * Stores hold application state. They respond to actions sent by the dispatcher
  * and broadcast change events to listeners, so they can grab the latest data.
- * The key thing to remember is that Store's do not have a set
+ * The key thing to remember is that the only way stores receive information
+ * from the outside world is via the dispatcher.
  */
 
 'use strict';
@@ -25,7 +26,6 @@ export default class Store extends EventEmitter {
   /**
    * Return a (shallow) copy of the store's internal state, so that it is
    * protected from mutation by the consumer.
-   *
    * @returns {object}
    */
   getState() {

--- a/src/Store.js
+++ b/src/Store.js
@@ -49,6 +49,11 @@ export default class Store extends EventEmitter {
     }
   }
 
+  replaceState(newState) {
+    this.state = Object.assign({}, newState);
+    this.emit('change');
+  }
+
   register(actionId, handler) {
     this._handlers.set(actionId, handler.bind(this));
   }

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -198,24 +198,23 @@ describe('Flux', () => {
     it('converts a serialized string into state and uses it to replace state of stores', () => {
       let flux = new Flux();
 
-      flux.createStore('foo', SerializableStore, null, 'foo state');
-      flux.createStore('bar', SerializableStore, null, 'bar state');
-      flux.createStore('baz', SerializableStore, null, 'baz state');
+      flux.createStore('foo', SerializableStore, null, { foo: 'bar' });
+      flux.createStore('bar', SerializableStore, null, { bar: 'baz' });
+      flux.createStore('baz', SerializableStore, null, { baz: 'foo' });
 
-      // Actual string values here are unimportant, as long as keys match
       flux.deserialize(`{
-        "foo": "foo",
-        "bar": "bar",
-        "baz": "baz"
+        "foo": "{}",
+        "bar": "{}",
+        "baz": "{}"
       }`);
 
       let fooStore = flux.getStore('foo');
       let barStore = flux.getStore('bar');
       let bazStore = flux.getStore('baz');
 
-      expect(fooStore.state).to.equal('foo state');
-      expect(barStore.state).to.equal('bar state');
-      expect(bazStore.state).to.equal('baz state');
+      expect(fooStore.state).to.deep.equal({ foo: 'bar' });
+      expect(barStore.state).to.deep.equal({ bar: 'baz' });
+      expect(bazStore.state).to.deep.equal({ baz: 'foo' });
     });
 
     it('throws if passed string is invalid JSON', () => {

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -111,12 +111,7 @@ describe('Store', () => {
     it('shallow merges old state with new state', () => {
       let store = new ExampleStore();
 
-      store.register(actionId, function(body) {
-        this.setState({ bar: body });
-      });
-
-      // Simulate dispatch
-      store.handler({ actionId, body: 'baz' });
+      store.setState({ bar: 'baz' });
 
       expect(store.state).to.deep.equal({
         foo: 'bar',
@@ -153,6 +148,28 @@ describe('Store', () => {
 
       expect(listener.calledOnce).to.be.true;
       expect(store.state).to.deep.equal({ foo: 'bar', bar: 'baz', baz: 'foo' });
+    });
+  });
+
+  describe('#replaceState()', () => {
+    it('replaces old state with new state', () => {
+      let store = new ExampleStore();
+
+      store.replaceState({ bar: 'baz' });
+
+      expect(store.state).to.deep.equal({
+        bar: 'baz',
+      });
+    });
+
+    it('emits change event', () => {
+      let store = new ExampleStore();
+      let listener = sinon.spy();
+      store.addListener('change', listener);
+
+      store.replaceState({ foo: 'bar' });
+
+      expect(listener.calledOnce).to.be.true;
     });
   });
 


### PR DESCRIPTION
Addresses #5. Adds `serialize()` and `deserialize()` methods to Flux class. Obvious use case is outputting initial state on the server, sending it to the client embedded in the HTML, then deserializing to avoid duplicate API calls on the initial render. Other potential use cases in the future include versioning ("snapshotting") and undo/redo.

- `serialize()` converts the entire app state to a JSON string
- `deserialize()` converts the string back into app state and emits change events on all stores
- Internally calls `serialize()` and `deserialize()` on each store instance. If any stores are missing those methods, an error is thrown with a helpful error explaining why.

Also adds `Store#replaceState()` which is analagous to the React component method of the same name.