### PR TITLE
Fix passing array of stores to FluxMixin

### DIFF
--- a/src/addons/FluxMixin.js
+++ b/src/addons/FluxMixin.js
@@ -116,7 +116,7 @@ export default function FluxMixin(...args) {
           [key]: stateGetter,
         };
       } else if (Array.isArray(stateGetterMap)) {
-        stateGetterMap.reduce((result, key) => {
+        stateGetterMap = stateGetterMap.reduce((result, key) => {
           result[key] = stateGetter;
           return result;
         }, {});

--- a/src/addons/__tests__/FluxMixin-test.js
+++ b/src/addons/__tests__/FluxMixin-test.js
@@ -289,6 +289,22 @@ describe('FluxMixin', () => {
       });
     });
 
+    it('converts array of stores to state getter', () => {
+      let flux = new Flux();
+
+      let component = TestUtils.renderIntoDocument(
+        <PropsComponent flux={flux} />
+      );
+
+      component.connectToStores(['test']);
+
+      flux.getActions('test').getSomething('foobar');
+
+      expect(component.state).to.deep.equal({
+        something: 'foobar',
+      });
+    });
+
     it('uses default getter if null is passed as getter', () => {
       let flux = new Flux();
 


### PR DESCRIPTION
Passing an array of store identifiers to FluxMixin as in the documentation wasn't working - this fixes it and adds a test to catch it!