### PR TITLE
Make FluxComponent not self-closing in example

### DIFF
--- a/docs/why-flux-component-is-better-than-flux-mixin.md
+++ b/docs/why-flux-component-is-better-than-flux-mixin.md
@@ -132,7 +132,7 @@ let BlogPostPage = React.createClass({
           posts: store => ({
             post: store.getPost(this.props.id),
           })
-        }}/>
+        }}>
           <BlogPost />
         </FluxComponent>
       </MainContentArea>


### PR DESCRIPTION
This component has children, so it should not start with a self-closing tag.