### PR TITLE
Return the Store/Actions instance during create.

### DIFF
--- a/src/Flux.js
+++ b/src/Flux.js
@@ -53,6 +53,8 @@ export default class Flux extends EventEmitter {
     store._token = token;
 
     this._stores[key] = store;
+
+    return store;
   }
 
   getStore(key) {
@@ -84,6 +86,8 @@ export default class Flux extends EventEmitter {
     actions.dispatchAsync = this.dispatchAsync.bind(this);
 
     this._actions[key] = actions;
+
+    return actions;
   }
 
   getActions(key) {

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -64,6 +64,14 @@ describe('Flux', () => {
       expect(spy1.getCall(0).args[0].body).to.equal('foobar');
       expect(spy2.calledWith('bar')).to.be.true;
     });
+
+    it('returns the created store instance', () => {
+      class ExampleStore extends Store {}
+
+      let flux = new Flux();
+      let store = flux.createStore('ExampleStore', ExampleStore);
+      expect(store).to.be.an.instanceOf(ExampleStore);
+    });
   });
 
   describe('#getStore()', () => {
@@ -101,6 +109,14 @@ describe('Flux', () => {
         + 'in its prototype chain. Make sure you\'re using the `extends` '
         + 'keyword: `class ForgotToExtendActions extends Actions { ... }`'
       );
+    });
+
+    it('returns the created action\'s instance', () => {
+      class TestActions extends Actions {}
+
+      let flux = new Flux();
+      let actions = flux.createActions('TestActions', TestActions);
+      expect(actions).to.be.an.instanceOf(TestActions);
     });
   });
 


### PR DESCRIPTION
During testing I found my self with a lot of createActions / createStores followed by the matching getters.

This PR lets you use the following syntax

```js
let flux = new Flux();
let sessionActions = flux.createActions('session', SessionActions);
let sessionStore = flux.createStore('session', SessionStore);

sessionActions.login(true);
assert.isTrue(sessionStore.isLoggedIn());
```

Might also be useful if you want to inject actions into stores directly

```js
export default class Flux extends Flummox {
  constructor() {
    super();

    let stargazersActions = this.createActions('stargazers', StargazerActions);
    let globalActions = this.createActions('global', GlobalActions);

    this.createStore('stargazers', StargazerStore, stargazersActions, globalActions);
    this.createStore('app', AppStore, globalActions);
  }
}
```