### PR TITLE
Actions TestUtils

### DIFF
--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -168,7 +168,7 @@ describe('Examples:', () => {
     describe('#newMessage action', () => {
       beforeEach(function() {
         this.flux = new Flummox();
-        this.messageActions = this.flux.createActions('messages', TestActions, ['newMessage']);
+        this.messageActions = this.flux.createActions('messages', TestActions(['newMessage']));
         this.messageStore = this.flux.createStore('messages', MessageStore, this.flux);
       });
 

--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -179,9 +179,7 @@ describe('Examples:', () => {
     describe('#newMessage action', () => {
       beforeEach(function() {
         this.flux = new Flummox();
-        this.messageActions = this.flux.createActions('messages', TestActions(['newMessage'], {
-          clear: true
-        }));
+        this.messageActions = this.flux.createActions('messages', TestActions(['newMessage'], ['clear']));
         this.messageStore = this.flux.createStore('messages', MessageStore, this.flux);
       });
 

--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -127,17 +127,28 @@ describe('Examples:', () => {
         super();
 
         let messageActions = flux.getActions('messages');
+
         this.registerAsync(
           messageActions.newMessage, 
           this.handleNewMessageBegin,
           this.handleNewMessageComplete,
           this.handleNewMessageFailed
         );
+
+        this.register(messageActions.clear, this.handleClearMessages);
+
         this.messageCounter = 0;
         this.state = {
           saving: false,
           messages: {}
         };
+      }
+
+      handleClearMessages() {
+        this.replaceState({
+          saving: false,
+          messages: {}
+        });
       }
 
       handleNewMessageBegin() {
@@ -168,7 +179,9 @@ describe('Examples:', () => {
     describe('#newMessage action', () => {
       beforeEach(function() {
         this.flux = new Flummox();
-        this.messageActions = this.flux.createActions('messages', TestActions(['newMessage']));
+        this.messageActions = this.flux.createActions('messages', TestActions(['newMessage'], {
+          clear: true
+        }));
         this.messageStore = this.flux.createStore('messages', MessageStore, this.flux);
       });
 
@@ -196,6 +209,16 @@ describe('Examples:', () => {
         
         expect(this.messageStore.state.saving).to.be.false;
         expect(this.messageStore.state.error).to.equal('failed to create message.');
+      });
+
+      it('clears messages', function () {
+        let action = this.messageActions.newMessage();
+        action.success('Hello, world!');
+
+        this.messageActions.clear();
+
+        expect(this.messageStore.state.saving).to.be.false;
+        expect(this.messageStore.state.messages).to.deep.equal({});
       });
     });
   });

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -1,0 +1,50 @@
+'use strict';
+
+import Actions from '../Actions';
+
+class TestActionsAsyncResponse {
+  constructor() {
+    this._success = [];
+    this._fail = [];
+  }
+
+  then(success, fail) {
+    if (isFunc(success)) {
+      this._success.push(success);
+    }
+
+    if (isFunc(fail)) {
+      this._fail.push(fail);
+    }
+
+    return this;
+  }
+
+  success(...successArgs) {
+    this._success.forEach(callback => callback.apply(this, successArgs));
+  }
+
+  fail(...failArgs) {
+    this._fail.forEach(callback => callback.apply(this, failArgs));
+  }
+
+  static defaultResponse() {
+    return new TestActionsAsyncResponse();
+  }
+}
+
+class TestActions extends Actions {
+  constructor(asyncActions) {
+    asyncActions.forEach(action => this.constructor.prototype[action] = TestActionsAsyncResponse.defaultResponse);
+    super();
+  }
+}
+
+function isFunc(func) {
+  return typeof func === 'function';
+}
+
+export {
+  TestActionsAsyncResponse,
+  TestActions,
+};

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -2,6 +2,32 @@
 
 import Actions from '../Actions';
 
+
+export function TestActions(asyncActions, syncActions) {
+  class TestActionsClass extends Actions {
+    constructor() {
+      super();
+    }
+  }
+
+  if (Array.isArray(asyncActions)) {
+    asyncActions.forEach(actionName => 
+      TestActionsClass.prototype[actionName] = TestActionsAsyncResponse.defaultResponse
+    );
+  }
+
+  if (syncActions) {
+    Object.keys(syncActions).forEach(actionName => {
+      let actionValue = syncActions[actionName];
+      // Ensure action value is a function.
+      let actionFunc = isFunc(actionValue) ? actionValue : () => actionValue;
+      TestActionsClass.prototype[actionName] = actionFunc;
+    });
+  }
+
+  return TestActionsClass;
+}
+
 class TestActionsAsyncResponse {
   constructor() {
     this._success = [];
@@ -31,32 +57,6 @@ class TestActionsAsyncResponse {
   static defaultResponse() {
     return new TestActionsAsyncResponse();
   }
-}
-
-
-export function TestActions(asyncActions, syncActions) {
-  class TestActionsClass extends Actions {
-    constructor() {
-      super();
-    }
-  }
-
-  if (Array.isArray(asyncActions)) {
-    asyncActions.forEach(actionName => 
-      TestActionsClass.prototype[actionName] = TestActionsAsyncResponse.defaultResponse
-    );
-  }
-
-  if (syncActions) {
-    Object.keys(syncActions).forEach(actionName => {
-      let actionValue = syncActions[actionName];
-      // Ensure action value is a function.
-      let actionFunc = isFunc(actionValue) ? actionValue : () => actionValue;
-      TestActionsClass.prototype[actionName] = actionFunc;
-    });
-  }
-
-  return TestActionsClass;
 }
 
 function isFunc(func) {

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -49,6 +49,10 @@ export function TestActions(asyncActions, syncActions) {
 
 class TestActionsSyncPromise {
   constructor() {
+    this.reset();
+  }
+
+  reset() {
     this._success = [];
     this._fail = [];
   }
@@ -66,11 +70,13 @@ class TestActionsSyncPromise {
   }
 
   success(...successArgs) {
-    this._success.forEach(callback => callback.apply(this, successArgs));
+    this._success.forEach(callback => callback(...successArgs));
+    this.reset();
   }
 
   fail(...failArgs) {
-    this._fail.forEach(callback => callback.apply(this, failArgs));
+    this._fail.forEach(callback => callback(...failArgs));
+    this.reset();
   }
 }
 

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -33,11 +33,21 @@ class TestActionsAsyncResponse {
   }
 }
 
-class TestActions extends Actions {
-  constructor(asyncActions) {
-    asyncActions.forEach(action => this.constructor.prototype[action] = TestActionsAsyncResponse.defaultResponse);
-    super();
+
+export function TestActions(asyncActions) {
+  class TestActionsClass extends Actions {
+    constructor() {
+      super();
+    }
   }
+
+  if (Array.isArray(asyncActions)) {
+    asyncActions.forEach(action => 
+      TestActionsClass.prototype[action] = TestActionsAsyncResponse.defaultResponse
+    );
+  }
+
+  return TestActionsClass;
 }
 
 function isFunc(func) {
@@ -45,6 +55,5 @@ function isFunc(func) {
 }
 
 export {
-  TestActionsAsyncResponse,
-  TestActions,
+  TestActionsAsyncResponse
 };

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -34,7 +34,7 @@ export function TestActions(asyncActions, syncActions) {
 
   if (Array.isArray(asyncActions)) {
     asyncActions.forEach(actionName => 
-      TestActionsClass.prototype[actionName] = TestActionsAsyncResponse.defaultResponse
+      TestActionsClass.prototype[actionName] = () => new TestActionsSyncPromise
     );
   }
 
@@ -47,7 +47,7 @@ export function TestActions(asyncActions, syncActions) {
   return TestActionsClass;
 }
 
-class TestActionsAsyncResponse {
+class TestActionsSyncPromise {
   constructor() {
     this._success = [];
     this._fail = [];
@@ -72,10 +72,6 @@ class TestActionsAsyncResponse {
   fail(...failArgs) {
     this._fail.forEach(callback => callback.apply(this, failArgs));
   }
-
-  static defaultResponse() {
-    return new TestActionsAsyncResponse();
-  }
 }
 
 function isFunc(func) {
@@ -83,5 +79,5 @@ function isFunc(func) {
 }
 
 export {
-  TestActionsAsyncResponse
+  TestActionsSyncPromise
 };

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -34,7 +34,7 @@ class TestActionsAsyncResponse {
 }
 
 
-export function TestActions(asyncActions) {
+export function TestActions(asyncActions, syncActions) {
   class TestActionsClass extends Actions {
     constructor() {
       super();
@@ -42,16 +42,25 @@ export function TestActions(asyncActions) {
   }
 
   if (Array.isArray(asyncActions)) {
-    asyncActions.forEach(action => 
-      TestActionsClass.prototype[action] = TestActionsAsyncResponse.defaultResponse
+    asyncActions.forEach(actionName => 
+      TestActionsClass.prototype[actionName] = TestActionsAsyncResponse.defaultResponse
     );
+  }
+
+  if (syncActions) {
+    Object.keys(syncActions).forEach(actionName => {
+      let actionValue = syncActions[actionName];
+      // Ensure action value is a function.
+      let actionFunc = isFunc(actionValue) ? actionValue : () => actionValue;
+      TestActionsClass.prototype[actionName] = actionFunc;
+    });
   }
 
   return TestActionsClass;
 }
 
 function isFunc(func) {
-  return typeof func === 'function';
+  return func && typeof func === 'function';
 }
 
 export {

--- a/src/addons/TestUtils.js
+++ b/src/addons/TestUtils.js
@@ -2,7 +2,29 @@
 
 import Actions from '../Actions';
 
-
+/**
+ * TestActions
+ *
+ * Exports a function that creates a dynamic actions class for use 
+ * with testing.
+ *
+ * The function expects the first argument to be an array of async
+ * action names. Sync actions can be defined in the same way by 
+ * passing a second array.
+ *
+ * When calling an async action a utility class will be returned which 
+ * can be completed by calling success(...args) or fail(...args). 
+ * 
+ * @example
+ * let actions = flux.createActions('actions', TestActions(['async1'], ['sync1']));
+ * let action = actions.async1();
+ *
+ * action.success('Action 1 succeeded');
+ * action.fail('Action 1 failed');
+ *
+ * actions.sync1();
+ * 
+ */
 export function TestActions(asyncActions, syncActions) {
   class TestActionsClass extends Actions {
     constructor() {
@@ -16,13 +38,10 @@ export function TestActions(asyncActions, syncActions) {
     );
   }
 
-  if (syncActions) {
-    Object.keys(syncActions).forEach(actionName => {
-      let actionValue = syncActions[actionName];
-      // Ensure action value is a function.
-      let actionFunc = isFunc(actionValue) ? actionValue : () => actionValue;
-      TestActionsClass.prototype[actionName] = actionFunc;
-    });
+  if (Array.isArray(syncActions)) {
+    syncActions.forEach(actionName => 
+      TestActionsClass.prototype[actionName] = () => true
+    );
   }
 
   return TestActionsClass;

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -62,8 +62,8 @@ describe('TestUtils', () => {
   describe('TestActions', () => {
     it('creates async actions', () => {
       let actions = new TestActions(['foo1', 'foo2']);
-      expect(actions.foo1).to.be.ok;
-      expect(actions.foo2).to.be.ok;
+      expect(actions.foo1).to.be.a('function');
+      expect(actions.foo2).to.be.a('function');
     })
 
     it('returns async action helper class', () => {

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+import { TestActionsAsyncResponse, TestActions } from '../TestUtils';
+import { Flux } from '../../Flux';
+import sinon from 'sinon';
+
+describe('TestUtils', () => {
+  describe('TestActionsAsyncResponse', () => {
+    it('then returns self', () => {
+      let asyncResp = new TestActionsAsyncResponse();
+      let self = asyncResp.then();
+
+      expect(self).to.equal(asyncResp);
+    });
+
+    it('calls success handler', () => {
+      let asyncResp = new TestActionsAsyncResponse();
+      let success = sinon.spy();
+      asyncResp.then(success);
+      asyncResp.success('foo');
+
+      expect(success.calledOnce).to.be.true;
+      expect(success.firstCall.args[0]).to.equal('foo');
+    });
+
+    it('calls fail handler', () => {
+      let asyncResp = new TestActionsAsyncResponse();
+      let fail = sinon.spy();
+      asyncResp.then(null, fail);
+      asyncResp.fail('foo');
+
+      expect(fail.calledOnce).to.be.true;
+      expect(fail.firstCall.args[0]).to.equal('foo');
+    });
+
+    it('supports multiple then handlers', () => {
+      let asyncResp = new TestActionsAsyncResponse();
+      let success1 = sinon.spy();
+      let success2 = sinon.spy();
+      let fail1 = sinon.spy();
+      let fail2 = sinon.spy();
+
+      asyncResp.then(success1, fail1);
+      asyncResp.then(success2, fail2);
+
+      asyncResp.success('foo');
+      asyncResp.fail('foo');
+
+      expect(success1.calledOnce).to.be.true;
+      expect(success1.firstCall.args[0]).to.equal('foo');
+      expect(fail1.calledOnce).to.be.true;
+      expect(fail1.firstCall.args[0]).to.equal('foo');
+
+      expect(success2.calledOnce).to.be.true;
+      expect(success2.firstCall.args[0]).to.equal('foo');
+      expect(fail2.calledOnce).to.be.true;
+      expect(fail2.firstCall.args[0]).to.equal('foo');
+
+    });
+  });
+
+  describe('TestActions', () => {
+    it('creates async actions', () => {
+      let actions = new TestActions(['foo1', 'foo2']);
+      expect(actions.foo1).to.be.ok;
+      expect(actions.foo2).to.be.ok;
+    })
+
+    it('returns async action helper class', () => {
+      let flux = new Flux();
+      let actions = flux.createActions('actions', TestActions, ['foo']);
+      let fooResp = actions.foo();
+
+      expect(fooResp).to.be.an.instanceof(TestActionsAsyncResponse);
+    })
+  });
+});

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -38,17 +38,25 @@ describe('TestUtils', () => {
       let fail1 = sinon.spy();
       let fail2 = sinon.spy();
 
-      asyncResp.then(success1, fail1);
-      asyncResp.then(success2, fail2);
+      asyncResp
+        .then(success1)
+        .then(success2);
 
       asyncResp.success('foo');
+
+      asyncResp = new TestActionsSyncPromise();
+      asyncResp
+        .then(null, fail1)
+        .then(null, fail2);
+
       asyncResp.fail('foo');
 
       expect(success1.withArgs('foo').calledOnce).to.be.true;
-      expect(fail1.withArgs('foo').calledOnce).to.be.true;
-
       expect(success2.withArgs('foo').calledOnce).to.be.true;
+
+      expect(fail1.withArgs('foo').calledOnce).to.be.true;
       expect(fail2.withArgs('foo').calledOnce).to.be.true;
+
     });
   });
 

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -1,20 +1,20 @@
 'use strict';
 
-import { TestActionsAsyncResponse, TestActions } from '../TestUtils';
+import { TestActionsSyncPromise, TestActions } from '../TestUtils';
 import { Flux } from '../../Flux';
 import sinon from 'sinon';
 
 describe('TestUtils', () => {
-  describe('TestActionsAsyncResponse', () => {
+  describe('TestActionsSyncPromise', () => {
     it('then returns self', () => {
-      let asyncResp = new TestActionsAsyncResponse();
+      let asyncResp = new TestActionsSyncPromise();
       let self = asyncResp.then();
 
       expect(self).to.equal(asyncResp);
     });
 
     it('calls success handler', () => {
-      let asyncResp = new TestActionsAsyncResponse();
+      let asyncResp = new TestActionsSyncPromise();
       let success = sinon.spy();
       asyncResp.then(success);
       asyncResp.success('foo');
@@ -23,7 +23,7 @@ describe('TestUtils', () => {
     });
 
     it('calls fail handler', () => {
-      let asyncResp = new TestActionsAsyncResponse();
+      let asyncResp = new TestActionsSyncPromise();
       let fail = sinon.spy();
       asyncResp.then(null, fail);
       asyncResp.fail('foo');
@@ -32,7 +32,7 @@ describe('TestUtils', () => {
     });
 
     it('supports multiple then handlers', () => {
-      let asyncResp = new TestActionsAsyncResponse();
+      let asyncResp = new TestActionsSyncPromise();
       let success1 = sinon.spy();
       let success2 = sinon.spy();
       let fail1 = sinon.spy();
@@ -66,7 +66,7 @@ describe('TestUtils', () => {
       let actions = flux.createActions('actions', TestActions(['foo']));
       let fooResp = actions.foo();
 
-      expect(fooResp).to.be.an.instanceof(TestActionsAsyncResponse);
+      expect(fooResp).to.be.an.instanceof(TestActionsSyncPromise);
     });
 
     it('creates sync actions', () => {

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -71,19 +71,10 @@ describe('TestUtils', () => {
 
     it('creates sync actions', () => {
       let flux = new Flux();
-      let fooSpy = sinon.spy();
-
-      let actions = flux.createActions('actions', TestActions([], {
-        foo1: fooSpy,
-        foo2: 123
-      }));
+      let actions = flux.createActions('actions', TestActions([], ['foo1', 'foo2']));
 
       expect(actions.foo1).to.be.a('function');
       expect(actions.foo2).to.be.a('function');
-
-      actions.foo1('arg1', 'arg2');
-
-      expect(fooSpy.withArgs('arg1', 'arg2').calledOnce);
     });
   });
 });

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -19,8 +19,7 @@ describe('TestUtils', () => {
       asyncResp.then(success);
       asyncResp.success('foo');
 
-      expect(success.calledOnce).to.be.true;
-      expect(success.firstCall.args[0]).to.equal('foo');
+      expect(success.withArgs('foo').calledOnce).to.be.true;
     });
 
     it('calls fail handler', () => {
@@ -29,8 +28,7 @@ describe('TestUtils', () => {
       asyncResp.then(null, fail);
       asyncResp.fail('foo');
 
-      expect(fail.calledOnce).to.be.true;
-      expect(fail.firstCall.args[0]).to.equal('foo');
+      expect(fail.withArgs('foo').calledOnce).to.be.true;
     });
 
     it('supports multiple then handlers', () => {
@@ -46,25 +44,21 @@ describe('TestUtils', () => {
       asyncResp.success('foo');
       asyncResp.fail('foo');
 
-      expect(success1.calledOnce).to.be.true;
-      expect(success1.firstCall.args[0]).to.equal('foo');
-      expect(fail1.calledOnce).to.be.true;
-      expect(fail1.firstCall.args[0]).to.equal('foo');
+      expect(success1.withArgs('foo').calledOnce).to.be.true;
+      expect(fail1.withArgs('foo').calledOnce).to.be.true;
 
-      expect(success2.calledOnce).to.be.true;
-      expect(success2.firstCall.args[0]).to.equal('foo');
-      expect(fail2.calledOnce).to.be.true;
-      expect(fail2.firstCall.args[0]).to.equal('foo');
-
+      expect(success2.withArgs('foo').calledOnce).to.be.true;
+      expect(fail2.withArgs('foo').calledOnce).to.be.true;
     });
   });
 
   describe('TestActions', () => {
     it('creates async actions', () => {
       let actions = new TestActions(['foo1', 'foo2']);
+      
       expect(actions.foo1).to.be.a('function');
       expect(actions.foo2).to.be.a('function');
-    })
+    });
 
     it('returns async action helper class', () => {
       let flux = new Flux();
@@ -72,6 +66,6 @@ describe('TestUtils', () => {
       let fooResp = actions.foo();
 
       expect(fooResp).to.be.an.instanceof(TestActionsAsyncResponse);
-    })
+    });
   });
 });

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -54,15 +54,16 @@ describe('TestUtils', () => {
 
   describe('TestActions', () => {
     it('creates async actions', () => {
-      let actions = new TestActions(['foo1', 'foo2']);
-      
+      let TestActionsClass = TestActions(['foo1', 'foo2']);
+      let actions = new TestActionsClass();
+
       expect(actions.foo1).to.be.a('function');
       expect(actions.foo2).to.be.a('function');
     });
 
     it('returns async action helper class', () => {
       let flux = new Flux();
-      let actions = flux.createActions('actions', TestActions, ['foo']);
+      let actions = flux.createActions('actions', TestActions(['foo']));
       let fooResp = actions.foo();
 
       expect(fooResp).to.be.an.instanceof(TestActionsAsyncResponse);

--- a/src/addons/__tests__/TestUtils-test.js
+++ b/src/addons/__tests__/TestUtils-test.js
@@ -68,5 +68,22 @@ describe('TestUtils', () => {
 
       expect(fooResp).to.be.an.instanceof(TestActionsAsyncResponse);
     });
+
+    it('creates sync actions', () => {
+      let flux = new Flux();
+      let fooSpy = sinon.spy();
+
+      let actions = flux.createActions('actions', TestActions([], {
+        foo1: fooSpy,
+        foo2: 123
+      }));
+
+      expect(actions.foo1).to.be.a('function');
+      expect(actions.foo2).to.be.a('function');
+
+      actions.foo1('arg1', 'arg2');
+
+      expect(fooSpy.withArgs('arg1', 'arg2').calledOnce);
+    });
   });
 });


### PR DESCRIPTION
Heres a first pass at implementing #19, I was hoping to get some feedback.

This PR includes a new `TestActions` utility method which simplifies the boilerplate needed when testing actions.

heres an example:

```js
let actions = flux.createActions('actions', TestActions(['async1'], ['sync1']));
let testStore = flux.createStore('test', TestStore, flux);
let action = actions.async1();
action.success('Async 1 succeeded');

expect(testStore.state.message).to.equal('Async 1 succeeded');
```

Ive also updated the exampleFlux test to include an async example.

In order to support the `success() / fail()` sync syntax I had to return a fake promise which doesn't delay resolving. My only concern with this approach is it changes the behaviour slightly, promise's generally force resolving to be async using something like `setTimeout`.

I had removed support (8c1aa8a) for specifying the body sent to dispatcher on sync actions, we might want to restore this functionality before this is ready to be merged. 