### PR TITLE
FluxMixin: check if component is mounted when updating

### DIFF
--- a/src/addons/FluxMixin.js
+++ b/src/addons/FluxMixin.js
@@ -167,8 +167,10 @@ export default function FluxMixin(...args) {
         let initialStoreState = storeStateGetter(store);
 
         let listener = () => {
-          let state = storeStateGetter(store);
-          this.setState(state);
+          if (this.isMounted()) {
+            let state = storeStateGetter(store);
+            this.setState(state);
+          }
         };
 
         store.addListener('change', listener);

--- a/src/addons/__tests__/FluxMixin-test.js
+++ b/src/addons/__tests__/FluxMixin-test.js
@@ -127,30 +127,30 @@ describe('FluxMixin', () => {
   });
 
   it('ignores change event after unmounted', () => {
-      let flux = new Flux();
-      flux.getActions('test').getSomething('foo');
+    let flux = new Flux();
+    flux.getActions('test').getSomething('foo');
 
-      let getterMap = {
-          test: store => ({ something: store.state.something })
-      };
-      let Component = React.createClass({
-          mixins: [FluxMixin(getterMap)],
+    let getterMap = {
+      test: store => ({ something: store.state.something })
+    };
+    let Component = React.createClass({
+      mixins: [FluxMixin(getterMap)],
 
-          render() {
-              return null;
-          }
-      });
+      render() {
+        return null;
+      }
+    });
 
-      let container = document.createElement('div');
-      let component = React.render(<Component flux={flux} />, container);
-      let listener = flux.getStore('test').listeners('change')[0];
+    let container = document.createElement('div');
+    let component = React.render(<Component flux={flux} />, container);
+    let listener = flux.getStore('test').listeners('change')[0];
 
-      React.unmountComponentAtNode(container);
+    React.unmountComponentAtNode(container);
 
-      flux.getActions('test').getSomething('bar');
-      listener();
+    flux.getActions('test').getSomething('bar');
+    listener();
 
-      expect(component.state.something).to.equal('foo');
+    expect(component.state.something).to.equal('foo');
   });
 
   it('uses #connectToStores() to get initial state', () => {

--- a/src/addons/__tests__/FluxMixin-test.js
+++ b/src/addons/__tests__/FluxMixin-test.js
@@ -126,6 +126,33 @@ describe('FluxMixin', () => {
       );
   });
 
+  it('ignores change event after unmounted', () => {
+      let flux = new Flux();
+      flux.getActions('test').getSomething('foo');
+
+      let getterMap = {
+          test: store => ({ something: store.state.something })
+      };
+      let Component = React.createClass({
+          mixins: [FluxMixin(getterMap)],
+
+          render() {
+              return null;
+          }
+      });
+
+      let container = document.createElement('div');
+      let component = React.render(<Component flux={flux} />, container);
+      let listener = flux.getStore('test').listeners('change')[0];
+
+      React.unmountComponentAtNode(container);
+
+      flux.getActions('test').getSomething('bar');
+      listener();
+
+      expect(component.state.something).to.equal('foo');
+  });
+
   it('uses #connectToStores() to get initial state', () => {
     let flux = new Flux();
 


### PR DESCRIPTION
Not sure exactly how it happens, but I ran into this bug in a fairly complex application. Somehow the change events get run even after the component is unmounted by a parent component. I think it has to do with the parent and child both listening to the same change event, the parent change handler is invoked first which removes the child, then the child handler is invoked immediately after.

This fixes it in FluxMixin by checking if the component is mounted before updating the state.