### PR TITLE
README: fixed reference to Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Flummox is just Flux. It has no opinion on the rest of your stack. You don't eve
 * [Immutable.js](http://facebook.github.io/immutable-js/) — Using immutable data in your applications not only makes your application more performant, but it also simplifies state management in your stores. No more defensive copying! It also helps ensure isolation between stores by reducing the likelihood that you'll accidentally mutate a dispatched payload.
 * [React Router](https://github.com/rackt/react-router) — A complete routing solution for React, with excellent support for isomorphic applications.
 * [superagent](https://github.com/visionmedia/superagent) — An isomorphic AJAX library. Use it for all your data fetching.
-* [Babel](https://babeljs.io/) — Use next-generation JavaScript (ES6, and even some ES7) today. Once you've tried it, it's the only way to write JavaScript. 6to5 also very conveniently supports JSX compilation.
+* [Babel](https://babeljs.io/) — Use next-generation JavaScript (ES6, and even some ES7) today. Once you've tried it, it's the only way to write JavaScript. Babel also very conveniently supports JSX compilation.
 
 
 Inspiration and thanks


### PR DESCRIPTION
6to5 was still being referenced.