### PR TITLE
Fix FluxComponent with multiple children

### DIFF
--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -78,7 +78,7 @@ let FluxComponent = React.createClass({
       let child = children;
       return this.wrapChild(child);
     } else {
-      return <span>React.Children.map(children, this.wrapChild)</span>;
+      return <span>{React.Children.map(children, this.wrapChild)}</span>;
     }
   }
 


### PR DESCRIPTION
A FluxComponent with multiple children will render a span with the text: 
"React.Children.map(children, this.wrapChild)"

This change just wraps that function so it will be interpolated instead of output as a string.