### PR TITLE
Added missing `}` in mixin example code

### DIFF
--- a/docs/why-flux-component-is-better-than-flux-mixin.md
+++ b/docs/why-flux-component-is-better-than-flux-mixin.md
@@ -78,7 +78,7 @@ let BlogPostPage = React.createClass({
     <div>
       <SiteNavigation />
       <MainContentArea>
-        <BlogPost post={this.state.post />
+        <BlogPost post={this.state.post} />
       </MainContentArea>
       <SiteSidebar />
       <SiteFooter />


### PR DESCRIPTION
Just spotted a minor error in the docs.