### PR TITLE
Enable browserify bundles to use NODE_ENV

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,12 @@
     "eventemitter3": "~0.1.6",
     "flux": "~2.0.1",
     "object-assign": "~2.0.0",
-    "uniqueid": "~0.1.0"
-  }
+    "uniqueid": "~0.1.0",
+    "envify": "^3.0.0"
+  },
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
+  },
 }


### PR DESCRIPTION
This allows browserify bundles to use NODE_ENV in order to remove debug message when in production.  This matches the same technique used in React.  When used in conjunction with UglifyJS2 it also can remove unreachable code from the final build.