### PR TITLE
Improved state API: Allow stores to override default state type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Tags:
 - [Internal]
 - [Polish]
 
+## 3.0.0
+- [Breaking Change]
+  - Stores no longer use empty object as default state.
+- [Internal]
+  - Remove undocumented method `Store#getState()`.
+
 ## 2.13.1
 - **Bug Fix**
   - Small update to async actions so returned promise does not reject due to errors that occur in store handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Tags:
 
 ## 3.0.0
 - [Breaking Change]
-  - Stores no longer use empty object as default state.
+  - Stores no longer use empty object as default state. Default state is null, like React.
 - [Internal]
   - Remove undocumented method `Store#getState()`.
 

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -47,6 +47,23 @@ Performing optimistic updates
 
 A common pattern when performing server operations is to update the application's UI optimistically — before receiving a response from the server — then responding appropriately if the server returns an error. Use the method `registerAsync` to register separate handlers for the beginning of an asynchronous action and on success and failure. See below for details.
 
+Customizing top-level state type
+--------------------------------
+
+The default top-level state type (`this.state`) is a plain object. You can add any type of data to this structure, as in React. However, if you want even more control over state management, you can customize the top-level state type by overriding the static Store method `Store.assignState()`. This method is used internally to perform state changes. The default implementation is essentially a wrapper around `Object.assign()`:
+
+```js
+// Default implementation
+static assignState(oldState, newState) {
+  return Object.assign({}, oldState, newState);
+}
+```
+
+Things to keep in mind when overriding `assignState()`:
+
+- Should be non-mutative.
+- `assignState(null, newState)` should not throw and should return a copy of `newState`.
+
 
 Methods
 -------
@@ -153,4 +170,3 @@ If you use `Flux.serialize`, Flummox will try to call the static method `seriali
 ### deserialize(state)
 
 If you use `Flux.deserialize`, Flummox will try to call the static method `deserialize` on all your stores. Flummox will pass the appropriate serialized representation and expects an object, with which Flummox will call `replaceState` on your store.
-

--- a/src/Store.js
+++ b/src/Store.js
@@ -59,7 +59,7 @@ export default class Store extends EventEmitter {
     }
   }
 
-  static assignState(oldState = {}, newState) {
+  static assignState(oldState, newState) {
     return assign({}, oldState, newState);
   }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -17,7 +17,7 @@ export default class Store extends EventEmitter {
    * @type {Object}
    */
   constructor() {
-    this.state = undefined;
+    this.state = null;
 
     this._handlers = {};
     this._asyncHandlers = {};

--- a/src/Store.js
+++ b/src/Store.js
@@ -24,6 +24,15 @@ export default class Store extends EventEmitter {
   }
 
   setState(newState) {
+    // Do a transactional state update if a function is passed
+    if (typeof newState === 'function') {
+      const prevState = this._isHandlingDispatch
+        ? this._pendingState
+        : this.state;
+
+      newState = newState(prevState);
+    }
+
     if (this._isHandlingDispatch) {
       this._pendingState = this.constructor.mergeState(this._pendingState, newState);
       this._emitChangeAfterHandlingDispatch = true;

--- a/src/Store.js
+++ b/src/Store.js
@@ -34,7 +34,7 @@ export default class Store extends EventEmitter {
     }
 
     if (this._isHandlingDispatch) {
-      this._pendingState = this.constructor.mergeState(this._pendingState, newState);
+      this._pendingState = this.constructor.assignState(this._pendingState, newState);
       this._emitChangeAfterHandlingDispatch = true;
     } else {
 
@@ -44,22 +44,22 @@ export default class Store extends EventEmitter {
         + 'a mistake. Flux stores should manage their own state.'
         );
       }
-      this.state = this.constructor.mergeState(this.state, newState);
+      this.state = this.constructor.assignState(this.state, newState);
       this.emit('change');
     }
   }
 
   replaceState(newState) {
     if (this._isHandlingDispatch) {
-      this._pendingState = this.constructor.mergeState(undefined, newState);
+      this._pendingState = this.constructor.assignState(undefined, newState);
       this._emitChangeAfterHandlingDispatch = true;
     } else {
-      this.state = this.constructor.mergeState(undefined, newState);
+      this.state = this.constructor.assignState(undefined, newState);
       this.emit('change');
     }
   }
 
-  static mergeState(oldState = {}, newState) {
+  static assignState(oldState = {}, newState) {
     return assign({}, oldState, newState);
   }
 
@@ -148,7 +148,7 @@ export default class Store extends EventEmitter {
 
   _performHandler(_handler, ...args) {
     this._isHandlingDispatch = true;
-    this._pendingState = this.constructor.mergeState(undefined, this.state);
+    this._pendingState = this.constructor.assignState(undefined, this.state);
     this._emitChangeAfterHandlingDispatch = false;
 
     try {

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -495,7 +495,7 @@ describe('Flux', () => {
       expect(fooStore.state.deserialized).to.be.true;
       expect(barStore.state.stateString).to.equal('bar state');
       expect(barStore.state.deserialized).to.be.true;
-      expect(bazStore.state).to.be.undefined;
+      expect(bazStore.state).to.be.null;
     });
 
   });

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -329,10 +329,10 @@ describe('Store', () => {
     });
   });
 
-  describe('.mergeState', () => {
+  describe('.assignState', () => {
     it('can be overridden to enable custom state types', () => {
       class StringStore extends Store {
-        static mergeState(prevState, nextState) {
+        static assignState(prevState, nextState) {
           return [prevState, nextState]
             .filter(state => typeof state === 'string')
             .join('');

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -61,6 +61,11 @@ describe('Store', () => {
 
   });
 
+  it('default state is null', () => {
+    const store = new Store();
+    expect(store.state).to.be.null;
+  });
+
   describe('#registerAsync()', () => {
     it('registers handlers for begin, success, and failure of async action', async function() {
       let error = new Error();
@@ -310,6 +315,30 @@ describe('Store', () => {
       store.replaceState({ foo: 'bar' });
 
       expect(listener.calledOnce).to.be.true;
+    });
+  });
+
+  describe('.mergeState', () => {
+    it('can be overridden to enable custom state types', () => {
+      class StringStore extends Store {
+        static mergeState(prevState, nextState) {
+          return [prevState, nextState]
+            .filter(state => typeof state === 'string')
+            .join('');
+        }
+      }
+
+      const store = new StringStore();
+
+      expect(store.state).to.be.null;
+      store.setState('a');
+      expect(store.state).to.equal('a');
+      store.setState('b');
+      expect(store.state).to.equal('ab');
+      store.replaceState('xyz');
+      expect(store.state).to.equal('xyz');
+      store.setState('zyx');
+      expect(store.state).to.equal('xyzzyx');
     });
   });
 

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -228,6 +228,17 @@ describe('Store', () => {
       });
     });
 
+    it('supports transactional updates', () => {
+      const store = new Store();
+      store.state = { a: 1 };
+      store.setState(state => ({ a: state.a + 1 }));
+      expect(store.state.a).to.equal(2);
+      store.setState(state => ({ a: state.a + 1 }));
+      expect(store.state.a).to.equal(3);
+      store.setState(state => ({ a: state.a + 1 }));
+      expect(store.state.a).to.equal(4);
+    });
+
     it('emits change event', () => {
       let store = new ExampleStore();
       let listener = sinon.spy();

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -313,4 +313,40 @@ describe('Store', () => {
     });
   });
 
+  describe('#forceUpdate()', () => {
+    it('emits change event', () => {
+      let store = new ExampleStore();
+      let listener = sinon.spy();
+      store.addListener('change', listener);
+
+      store.forceUpdate();
+
+      expect(listener.calledOnce).to.be.true;
+    });
+
+    it('doesn\'t modify existing state', () => {
+      let store = new ExampleStore();
+      let listener = sinon.spy();
+      store.addListener('change', listener);
+
+      store.register(actionId, function() {
+        this.replaceState({ bar: 'baz' });
+        this.forceUpdate();
+
+        expect(this.state).to.deep.equal({ foo: 'bar' });
+        expect(listener.called).to.be.false;
+
+        this.setState({ foo: 'bar' });
+        this.forceUpdate();
+        this.replaceState({ baz: 'foo' });
+      });
+
+      // Simulate dispatch
+      store.handler({ actionId, body: 'foobar' });
+
+      expect(listener.calledOnce).to.be.true;
+      expect(store.state).to.deep.equal({ baz: 'foo' });
+    });
+  });
+
 });


### PR DESCRIPTION
Store state in Flummox 2.x is always an object, a la React components. This PR rewrites the store state methods so they are agnostic to the type of state. The default state type will still be an object.

- [x] Remove undocumented method `getState()`.
- [x] Add static method `assignState()`. The default implementation is just
  `Object.assign()`, but by overriding this single method, you could add
support for any type of state, e.g. Immutable.js Records. Method
signature is `assignState(oldState, newState)`. `oldState` may be undefined.
- [x] `setState()`, `replaceState()`, and private method `_performHandler()`
  have been rewritten to use `assignState()`.
- [x] Default state is null instead of an empty object.
- [x] Add tests for overriding `assignState()`
- [ ] Add docs

Also update state API to mirror new features in React 0.13

- [x] Transactional state updates: `this.setState((state) => ({count: state.count + 1}))`


Edit: renamed `mergeState()` to `assignState()` to better reflect how it should be implemented.