### PR TITLE
FluxMixin - single state getter when using an array of stores.

### DIFF
--- a/docs/api/FluxMixin.md
+++ b/docs/api/FluxMixin.md
@@ -75,11 +75,13 @@ Methods
 
 ```js
 connectToStores(string storeKey [, function stateGetter])
-connectToStores(Array<string> storeKeys)
-connectToStores(object stateGetterMap)
+connectToStores(Array<string> storeKeys [, function stateGetter])
+connectToStores(object stateGetterMap [, function stateGetter])
 ```
 
-Synchronize component state with state from Flux stores. Pass a single store key, an array of store keys, or a map of store keys to getter functions. In the single store key form, you can also specific a custom state getter as the second argument.
+Synchronize component state with state from Flux stores. Pass a single store key, an array of store keys, or a map of store keys to getter functions. You can also specify a custom state getter as the second argument, the default state getter will return the entire store state (a reduce is performed on the entire store state when using an array or store keys).
+
+When using an array of store keys, the custom state getter is called with an array of store instances (same order as keys) as the first argument. Otherwise only a single store instance is passed to the custom state getter.
 
 Returns the initial combined state of the specified stores.
 

--- a/src/addons/__tests__/fluxMixin-test.js
+++ b/src/addons/__tests__/fluxMixin-test.js
@@ -341,19 +341,47 @@ describe('fluxMixin', () => {
       });
     });
 
-    it('converts array of stores to state getter', () => {
+    it('calls default state getter once with array of stores', () => {
       let flux = new Flux();
+
+      flux.getStore('test2').setState({ otherThing: 'barbaz' });
 
       let component = TestUtils.renderIntoDocument(
         <ComponentWithFluxMixin key="test" flux={flux} />
       );
 
-      component.connectToStores(['test']);
+      component.connectToStores(['test', 'test2']);
 
       flux.getActions('test').getSomething('foobar');
 
       expect(component.state).to.deep.equal({
         something: 'foobar',
+        otherThing: 'barbaz'
+      });
+    });
+
+    it('calls custom state getter once with array of stores', () => {
+      let flux = new Flux();
+      let testStore = flux.getStore('test');
+      let test2Store = flux.getStore('test2');
+
+      testStore._testId = 'test';
+      test2Store._testId = 'test2';
+
+      let component = TestUtils.renderIntoDocument(
+        <ComponentWithFluxMixin key="test" flux={flux} />
+      );
+
+      let stateGetter = sinon.stub().returns({ foo: 'bar' });
+      let state = component.connectToStores(['test', 'test2'], stateGetter);
+
+      expect(stateGetter.calledOnce).to.be.true;
+      // Use _testId as unique identefier on store.
+      expect(stateGetter.firstCall.args[0][0]._testId).to.equal('test');
+      expect(stateGetter.firstCall.args[0][1]._testId).to.equal('test2');
+
+      expect(state).to.deep.equal({
+        foo: 'bar'
       });
     });
 

--- a/src/addons/__tests__/fluxMixin-test.js
+++ b/src/addons/__tests__/fluxMixin-test.js
@@ -376,7 +376,7 @@ describe('fluxMixin', () => {
       let state = component.connectToStores(['test', 'test2'], stateGetter);
 
       expect(stateGetter.calledOnce).to.be.true;
-      // Use _testId as unique identefier on store.
+      // Use _testId as unique identifier on store.
       expect(stateGetter.firstCall.args[0][0]._testId).to.equal('test');
       expect(stateGetter.firstCall.args[0][1]._testId).to.equal('test2');
 

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -52,7 +52,7 @@ export default function fluxMixin(...args) {
     },
 
     getInitialState() {
-      this._fluxStateGetters = {};
+      this._fluxStateGetters = [];
       this._fluxListeners = {};
       this._fluxDidSyncStoreState = false;
       this.flux = this.props.flux || this.context.flux;
@@ -93,18 +93,10 @@ export default function fluxMixin(...args) {
     },
 
     getStoreState() {
-      let state = {};
-
-      for (let key in this._fluxStateGetters) {
-        let storeStateGetter = this._fluxStateGetters[key];
-        let store = this.flux.getStore(key);
-
-        let storeState = storeStateGetter(store);
-
-        assign(state, storeState);
-      }
-
-      return state;
+      return this._fluxStateGetters.reduce((result, stateGetter) =>
+        assign(result, stateGetter.getter(stateGetter.stores)),
+        {}
+      );
     },
 
     /**
@@ -131,24 +123,8 @@ export default function fluxMixin(...args) {
      * @type {string|array|object} stateGetterMap - map of keys to getters
      * @returns {object} Combined initial state of stores
      */
-    connectToStores(stateGetterMap = {}, stateGetter = defaultStateGetter) {
-      let initialState = {};
-
-      // Ensure that stateGetterMap is an object
-      if (typeof stateGetterMap === 'string') {
-        let key = stateGetterMap;
-
-        stateGetterMap = {
-          [key]: stateGetter,
-        };
-      } else if (Array.isArray(stateGetterMap)) {
-        stateGetterMap = stateGetterMap.reduce((result, key) => {
-          result[key] = stateGetter;
-          return result;
-        }, {});
-      }
-
-      for (let key in stateGetterMap) {
+    connectToStores(stateGetterMap = {}, stateGetter = null) {
+      let getStore = (key) => {
         let store = this.flux.getStore(key);
 
         if (typeof store === 'undefined') {
@@ -157,25 +133,57 @@ export default function fluxMixin(...args) {
           );
         }
 
-        let storeStateGetter = stateGetterMap[key];
+        return store;
+      };
 
-        if (storeStateGetter === null) storeStateGetter = defaultStateGetter;
+      if (typeof stateGetterMap === 'string') {
+        let key = stateGetterMap;
+        let store = getStore(key);
+        let getter = stateGetter || defaultStateGetter;
 
-        storeStateGetter = storeStateGetter.bind(this);
-        this._fluxStateGetters[key] = storeStateGetter;
+        getter = getter.bind(this);
 
-        let initialStoreState = storeStateGetter(store);
-
-        let listener = createStoreListener(this, store, storeStateGetter)
-          .bind(this);
+        this._fluxStateGetters.push({ stores: store, getter });
+        let listener = createStoreListener(this, store, getter)
+            .bind(this);
 
         store.addListener('change', listener);
         this._fluxListeners[key] = listener;
+      } else if (Array.isArray(stateGetterMap)) {
+        let stores = stateGetterMap.map(getStore);
+        let getter = stateGetter || defaultReduceStateGetter;
 
-        assign(initialState, initialStoreState);
+        getter = getter.bind(this);
+
+        this._fluxStateGetters.push({ stores, getter });
+
+        let listener = createStoreListener(this, stores, getter)
+            .bind(this);
+
+        stateGetterMap.forEach((key, index) => {
+          let store = stores[index];
+          store.addListener('change', listener);
+          this._fluxListeners[key] = listener;
+        });
+
+      } else {
+        for (let key in stateGetterMap) {
+          let store = getStore(key);
+          let getter = stateGetterMap[key] || defaultStateGetter;
+
+          getter = getter.bind(this);
+
+          this._fluxStateGetters.push({ stores: store, getter });
+
+          let listener = createStoreListener(this, store, getter)
+            .bind(this);
+
+          store.addListener('change', listener);
+          this._fluxListeners[key] = listener;
+        }
       }
 
-      return initialState;
+      return this.getStoreState();
     }
 
   };
@@ -193,4 +201,11 @@ function createStoreListener(component, store, storeStateGetter) {
 
 function defaultStateGetter(store) {
   return store.state;
+}
+
+function defaultReduceStateGetter(stores) {
+  return stores.reduce((result, store) =>
+    assign(result, store.state),
+    {}
+  );
 }

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -108,8 +108,10 @@ export default function fluxMixin(...args) {
      * If no state getter is specified, the default getter is used, which simply
      * returns the entire store state.
      *
-     * The second form accepts an array of store keys. With this form, every
-     * store uses the default state getter.
+     * The second form accepts an array of store keys. With this form, the state
+     * getter is called once with an array of store instances (in the same order
+     * as the store keys). the default getter performance a reduce on the entire
+     * state for each store.
      *
      * The last form accepts an object of store keys mapped to state getters. As
      * a shortcut, you can pass `null` as a state getter to use the default

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -93,8 +93,8 @@ export default function fluxMixin(...args) {
     },
 
     getStoreState() {
-      return this._fluxStateGetters.reduce((result, stateGetter) =>
-        assign(result, stateGetter.getter(stateGetter.stores)),
+      return this._fluxStateGetters.reduce(
+        (result, stateGetter) => assign(result, stateGetter.getter(stateGetter.stores)),
         {}
       );
     },
@@ -206,8 +206,8 @@ function defaultStateGetter(store) {
 }
 
 function defaultReduceStateGetter(stores) {
-  return stores.reduce((result, store) =>
-    assign(result, store.state),
+  return stores.reduce(
+    (result, store) => assign(result, store.state),
     {}
   );
 }


### PR DESCRIPTION
This PR implements the api discussed in #43 when using `connectToStores` with an array of store keys.

This will be a breaking change if people are using `connectToStores` with both an array and custom state getter.

