### PR TITLE
Reproduce failing test for simulating action

### DIFF
--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -1,4 +1,6 @@
+import sinon from 'sinon';
 import { Flummox, Store, Actions } from '../Flux';
+import * as TestUtils from '../addons/TestUtils';
 
 describe('Examples:', () => {
 
@@ -107,6 +109,16 @@ describe('Examples:', () => {
           id: 0,
         },
       });
+    });
+
+    it('simulates action to create message', () => {
+      let flux = new Flux();
+      let messageStore = flux.getStore('messages');
+      let spy = sinon.spy(messageStore, 'handleNewMessage');
+
+      TestUtils.simulateAction(messageStore, 'newMessage', 'Hello, world!');
+      expect(spy.callCount).to.equal(1);
+      expect(spy.calledWith('Hello, world!')).to.be.true;
     });
   });
 


### PR DESCRIPTION
@acdlite I was able to reproduce the failing test. 

``` bash
  85 passing (78ms)
  1 failing

  1) Examples: Messages simulates action to create message:

      AssertionError: expected 0 to equal 1
      + expected - actual

      +1
      -0
```

Refs https://github.com/acdlite/flummox/issues/71
/cc @tappleby 
