### PR TITLE
More functional FluxComponent / connectToStores implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Tags:
   - The array form of `connectToStore()` accepts a single state getter as the second parameter, which is passed an array of stores corresponding to the passed keys.
   - State getters are no longer auto-bound to the component. Props are passed as the second parameter.
   - Directly-nested FluxComponents warn about mismatched parent and owner context. Not sure how to fix this yet, but it will work because of prop transfer, anyway.
+  - `connectToStores()` no longer checks if component is mounted before updating, since `isMounted()` is deprecated in React 0.13. 99% of the time, this shouldn't be a problem, and it's easily worked around using the `render` prop. Let me know if this is a serious issue for you.
 - **Internal**
   - Remove undocumented method `Store#getState()`.
 

--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -63,20 +63,28 @@ class FluxComponent extends React.Component {
   }
 
   wrapChild(child) {
-    let { children, connectToStores, ...props } = this.props;
+    let { children, connectToStores, ...extraProps } = this.props;
 
     return React.cloneElement(
       child,
-      assign(
-        { flux: this.flux },
-        this.state,
-        props
-      )
+      this.getChildProps()
+    );
+  }
+
+  getChildProps() {
+    let { children, render, ...extraProps } = this.props;
+
+    return assign(
+      { flux: this.getFlux() },
+      this.state,
+      extraProps
     );
   }
 
   render() {
-    let { children } = this.props;
+    let { children, render, ...extraProps } = this.props;
+
+    if (typeof render === 'function') return render(this.getChildProps());
 
     if (!children) return null;
 

--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -48,16 +48,19 @@
  */
 
 import React from 'react';
-import fluxMixin from './fluxMixin';
+import { instanceMethods, staticProperties } from './reactComponentMethods';
 import assign from 'object-assign';
 
-let FluxComponent = React.createClass({
+class FluxComponent extends React.Component {
+  constructor(props, context) {
+    super(props, context);
 
-  mixins: [fluxMixin()],
+    this.initialize();
 
-  getInitialState() {
-    return this.connectToStores(this.props.connectToStores);
-  },
+    this.state = this.connectToStores(props.connectToStores);
+
+    this.wrapChild = this.wrapChild.bind(this);
+  }
 
   wrapChild(child) {
     let { children, connectToStores, ...props } = this.props;
@@ -70,7 +73,7 @@ let FluxComponent = React.createClass({
         props
       )
     );
-  },
+  }
 
   render() {
     let { children } = this.props;
@@ -84,7 +87,13 @@ let FluxComponent = React.createClass({
       return <span>{React.Children.map(children, this.wrapChild)}</span>;
     }
   }
+}
 
-});
+assign(
+  FluxComponent.prototype,
+  instanceMethods
+);
+
+assign(FluxComponent, staticProperties);
 
 export default FluxComponent;

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -176,4 +176,26 @@ describe('FluxComponent', () => {
     expect(div.props.something).to.equal('something else');
   });
 
+  it('uses `render` prop for custom rendering, if it exists', () => {
+    let flux = new Flux();
+    let actions = flux.getActions('test');
+
+    let tree = TestUtils.renderIntoDocument(
+      <FluxComponent
+        flux={flux}
+        connectToStores="test"
+        render={props =>
+          <div something={props.something} />
+        }
+      />
+    );
+
+    let div = TestUtils.findRenderedDOMComponentWithTag(tree, 'div');
+
+    actions.getSomething('something good');
+    expect(div.props.something).to.equal('something good');
+    actions.getSomething('something else');
+    expect(div.props.something).to.equal('something else');
+  });
+
 });

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -64,7 +64,7 @@ describe('FluxComponent', () => {
     expect(propsComponent.flux).to.be.an.instanceof(Flummox);
   });
 
-  it('passes connectToStore prop to FluxMixin\'s connectToStores()', () => {
+  it('passes connectToStore prop to reactComponentMethod connectToStores()', () => {
     let flux = new Flux();
     let actions = flux.getActions('test');
 

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -1,14 +1,8 @@
 /**
  * fluxMixin
  *
- * Exports a function that creates a React component mixin. The mixin exposes
- * a Flux instance as `this.flux`. This requires that flux be passed as either
- * context or as a prop (prop takes precedence). Children also are given access
- * to flux instance as `context.flux`.
- *
- * It also adds the method `connectToStores()`, which ensures that the component
- * state stays in sync with the specified Flux stores. See the inline docs
- * of `connectToStores` for details.
+ * Exports a function that creates a React component mixin. Implements methods
+ * from reactComponentMethods.
  *
  * Any arguments passed to the mixin creator are passed to `connectToStores()`
  * and used as the return value of `getInitialState()`. This lets you handle
@@ -30,185 +24,17 @@
 
 import { PropTypes } from 'react';
 import { Flux } from '../Flux';
+import reactComponentMethods from './reactComponentMethods';
 import assign from 'object-assign';
 
 export default function fluxMixin(...args) {
-
-  return {
-
-    contextTypes: {
-      flux: PropTypes.instanceOf(Flux),
-    },
-
-    childContextTypes: {
-      flux: PropTypes.instanceOf(Flux),
-    },
-
-    getChildContext() {
-      let flux = this.getFlux();
-
-      if (!flux) return {};
-
-      return {
-        flux: this.getFlux()
-      };
-    },
-
-    getFlux() {
-      return this.props.flux || this.context.flux;
-    },
-
-    getInitialState() {
-      this._fluxStateGetters = [];
-      this._fluxListeners = {};
-      this._fluxDidSyncStoreState = false;
-      this.flux = this.getFlux();
-
-      if (!(this.flux instanceof Flux)) {
-        // TODO: print the actual class name here
-        throw new Error(
-          `fluxMixin: Could not find Flux instance. Ensure that your component `
-        + `has either \`this.context.flux\` or \`this.props.flux\`.`
-        );
-      }
-
-      return this.connectToStores(...args);
-    },
-
-    componentWillUnmount() {
-      let flux = this.getFlux();
-
-      for (let key in this._fluxListeners) {
-        if (!this._fluxListeners.hasOwnProperty(key)) continue;
-
-        let store = flux.getStore(key);
-        if (typeof store === 'undefined') continue;
-
-        let listener = this._fluxListeners[key];
-
-        store.removeListener('change', listener);
+  return assign(
+    {
+      getInitialState() {
+        this.initialize();
+        return this.connectToStores(...args);
       }
     },
-
-    componentWillReceiveProps(nextProps) {
-      this.updateStores(nextProps);
-    },
-
-    updateStores(props = this.props) {
-      let state = this.getStoreState(props);
-      this.setState(state);
-    },
-
-    getStoreState(props = this.props) {
-      return this._fluxStateGetters.reduce(
-        (result, stateGetter) => {
-          const { getter, stores } = stateGetter;
-          const stateFromStores = getter(stores, props);
-          return assign(result, stateFromStores);
-        }, {}
-      );
-    },
-
-    /**
-     * Connect component to stores, get the combined initial state, and
-     * subscribe to future changes. There are three ways to call it. The
-     * simplest is to pass a single store key and, optionally, a state getter.
-     * The state getter is a function that takes the store as a parameter and
-     * returns the state that should be passed to the component's `setState()`.
-     * If no state getter is specified, the default getter is used, which simply
-     * returns the entire store state.
-     *
-     * The second form accepts an array of store keys. With this form, the state
-     * getter is called once with an array of store instances (in the same order
-     * as the store keys). the default getter performance a reduce on the entire
-     * state for each store.
-     *
-     * The last form accepts an object of store keys mapped to state getters. As
-     * a shortcut, you can pass `null` as a state getter to use the default
-     * state getter.
-     *
-     * Returns the combined initial state of all specified stores.
-     *
-     * This way you can write all the initialization and update logic in a single
-     * location, without having to mess with adding/removing listeners.
-     *
-     * @type {string|array|object} stateGetterMap - map of keys to getters
-     * @returns {object} Combined initial state of stores
-     */
-    connectToStores(stateGetterMap = {}, stateGetter = null) {
-      let flux = this.getFlux();
-
-      let getStore = (key) => {
-        let store = flux.getStore(key);
-
-        if (typeof store === 'undefined') {
-          throw new Error(
-            `connectToStores(): Store with key '${key}' does not exist.`
-          );
-        }
-
-        return store;
-      };
-
-      if (typeof stateGetterMap === 'string') {
-        let key = stateGetterMap;
-        let store = getStore(key);
-        let getter = stateGetter || defaultStateGetter;
-
-        this._fluxStateGetters.push({ stores: store, getter });
-        let listener = createStoreListener(this, store, getter);
-
-        store.addListener('change', listener);
-        this._fluxListeners[key] = listener;
-      } else if (Array.isArray(stateGetterMap)) {
-        let stores = stateGetterMap.map(getStore);
-        let getter = stateGetter || defaultReduceStateGetter;
-
-        this._fluxStateGetters.push({ stores, getter });
-        let listener = createStoreListener(this, stores, getter);
-
-        stateGetterMap.forEach((key, index) => {
-          let store = stores[index];
-          store.addListener('change', listener);
-          this._fluxListeners[key] = listener;
-        });
-
-      } else {
-        for (let key in stateGetterMap) {
-          let store = getStore(key);
-          let getter = stateGetterMap[key] || defaultStateGetter;
-
-          this._fluxStateGetters.push({ stores: store, getter });
-          let listener = createStoreListener(this, store, getter);
-
-          store.addListener('change', listener);
-          this._fluxListeners[key] = listener;
-        }
-      }
-
-      return this.getStoreState();
-    }
-
-  };
-
-};
-
-function createStoreListener(component, store, storeStateGetter) {
-  return function() {
-    if (this.isMounted()) {
-      let state = storeStateGetter(store, this.props);
-      this.setState(state);
-    }
-  }.bind(component);
-}
-
-function defaultStateGetter(store) {
-  return store.state;
-}
-
-function defaultReduceStateGetter(stores) {
-  return stores.reduce(
-    (result, store) => assign(result, store.state),
-    {}
+    reactComponentMethods
   );
-}
+};

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -28,13 +28,13 @@ import { instanceMethods, staticProperties } from './reactComponentMethods';
 import assign from 'object-assign';
 
 export default function fluxMixin(...args) {
+  function getInitialState() {
+    this.initialize();
+    return this.connectToStores(...args);
+  }
+
   return assign(
-    {
-      getInitialState() {
-        this.initialize();
-        return this.connectToStores(...args);
-      }
-    },
+    { getInitialState },
     instanceMethods,
     staticProperties
   );

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -24,7 +24,7 @@
 
 import { PropTypes } from 'react';
 import { Flux } from '../Flux';
-import reactComponentMethods from './reactComponentMethods';
+import { instanceMethods, staticProperties } from './reactComponentMethods';
 import assign from 'object-assign';
 
 export default function fluxMixin(...args) {
@@ -35,6 +35,7 @@ export default function fluxMixin(...args) {
         return this.connectToStores(...args);
       }
     },
-    reactComponentMethods
+    instanceMethods,
+    staticProperties
   );
 };

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -1,0 +1,193 @@
+/**
+ * React Component methods. These are the primitives used to implement
+ * fluxMixin and FluxComponent.
+ *
+ * Exposes a Flux instance as `this.flux`. This requires that flux be passed as
+ * either context or as a prop (prop takes precedence). Children also are given
+ * access to flux instance as `context.flux`.
+ *
+ * It also adds the method `connectToStores()`, which ensures that the component
+ * state stays in sync with the specified Flux stores. See the inline docs
+ * of `connectToStores` for details.
+ */
+
+ import { PropTypes } from 'react';
+ import { Flux } from '../Flux';
+ import assign from 'object-assign';
+
+ const reactComponentMethods = {
+
+   contextTypes: {
+     flux: PropTypes.instanceOf(Flux),
+   },
+
+   childContextTypes: {
+     flux: PropTypes.instanceOf(Flux),
+   },
+
+   getChildContext() {
+     let flux = this.getFlux();
+
+     if (!flux) return {};
+
+     return {
+       flux: this.getFlux()
+     };
+   },
+
+   getFlux() {
+     return this.props.flux || this.context.flux;
+   },
+
+   initialize() {
+     this._fluxStateGetters = [];
+     this._fluxListeners = {};
+     this._fluxDidSyncStoreState = false;
+     this.flux = this.getFlux();
+
+     if (!(this.flux instanceof Flux)) {
+       // TODO: print the actual class name here
+       throw new Error(
+         `fluxMixin: Could not find Flux instance. Ensure that your component `
+       + `has either \`this.context.flux\` or \`this.props.flux\`.`
+       );
+     }
+   },
+
+   componentWillUnmount() {
+     let flux = this.getFlux();
+
+     for (let key in this._fluxListeners) {
+       if (!this._fluxListeners.hasOwnProperty(key)) continue;
+
+       let store = flux.getStore(key);
+       if (typeof store === 'undefined') continue;
+
+       let listener = this._fluxListeners[key];
+
+       store.removeListener('change', listener);
+     }
+   },
+
+   componentWillReceiveProps(nextProps) {
+     this.updateStores(nextProps);
+   },
+
+   updateStores(props = this.props) {
+     let state = this.getStoreState(props);
+     this.setState(state);
+   },
+
+   getStoreState(props = this.props) {
+     return this._fluxStateGetters.reduce(
+       (result, stateGetter) => {
+         const { getter, stores } = stateGetter;
+         const stateFromStores = getter(stores, props);
+         return assign(result, stateFromStores);
+       }, {}
+     );
+   },
+
+   /**
+    * Connect component to stores, get the combined initial state, and
+    * subscribe to future changes. There are three ways to call it. The
+    * simplest is to pass a single store key and, optionally, a state getter.
+    * The state getter is a function that takes the store as a parameter and
+    * returns the state that should be passed to the component's `setState()`.
+    * If no state getter is specified, the default getter is used, which simply
+    * returns the entire store state.
+    *
+    * The second form accepts an array of store keys. With this form, the state
+    * getter is called once with an array of store instances (in the same order
+    * as the store keys). the default getter performance a reduce on the entire
+    * state for each store.
+    *
+    * The last form accepts an object of store keys mapped to state getters. As
+    * a shortcut, you can pass `null` as a state getter to use the default
+    * state getter.
+    *
+    * Returns the combined initial state of all specified stores.
+    *
+    * This way you can write all the initialization and update logic in a single
+    * location, without having to mess with adding/removing listeners.
+    *
+    * @type {string|array|object} stateGetterMap - map of keys to getters
+    * @returns {object} Combined initial state of stores
+    */
+   connectToStores(stateGetterMap = {}, stateGetter = null) {
+     let flux = this.getFlux();
+
+     let getStore = (key) => {
+       let store = flux.getStore(key);
+
+       if (typeof store === 'undefined') {
+         throw new Error(
+           `connectToStores(): Store with key '${key}' does not exist.`
+         );
+       }
+
+       return store;
+     };
+
+     if (typeof stateGetterMap === 'string') {
+       let key = stateGetterMap;
+       let store = getStore(key);
+       let getter = stateGetter || defaultStateGetter;
+
+       this._fluxStateGetters.push({ stores: store, getter });
+       let listener = createStoreListener(this, store, getter);
+
+       store.addListener('change', listener);
+       this._fluxListeners[key] = listener;
+     } else if (Array.isArray(stateGetterMap)) {
+       let stores = stateGetterMap.map(getStore);
+       let getter = stateGetter || defaultReduceStateGetter;
+
+       this._fluxStateGetters.push({ stores, getter });
+       let listener = createStoreListener(this, stores, getter);
+
+       stateGetterMap.forEach((key, index) => {
+         let store = stores[index];
+         store.addListener('change', listener);
+         this._fluxListeners[key] = listener;
+       });
+
+     } else {
+       for (let key in stateGetterMap) {
+         let store = getStore(key);
+         let getter = stateGetterMap[key] || defaultStateGetter;
+
+         this._fluxStateGetters.push({ stores: store, getter });
+         let listener = createStoreListener(this, store, getter);
+
+         store.addListener('change', listener);
+         this._fluxListeners[key] = listener;
+       }
+     }
+
+     return this.getStoreState();
+   }
+
+ };
+
+ export default reactComponentMethods;
+
+ function createStoreListener(component, store, storeStateGetter) {
+   return function() {
+     if (this.isMounted()) {
+       let state = storeStateGetter(store, this.props);
+       this.setState(state);
+     }
+   }.bind(component);
+ }
+
+ function defaultStateGetter(store) {
+   return store.state;
+ }
+
+ function defaultReduceStateGetter(stores) {
+   return stores.reduce(
+     (result, store) => assign(result, store.state),
+     {}
+   );
+ }

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -15,15 +15,7 @@
  import { Flux } from '../Flux';
  import assign from 'object-assign';
 
- const reactComponentMethods = {
-
-   contextTypes: {
-     flux: PropTypes.instanceOf(Flux),
-   },
-
-   childContextTypes: {
-     flux: PropTypes.instanceOf(Flux),
-   },
+ const instanceMethods = {
 
    getChildContext() {
      let flux = this.getFlux();
@@ -170,7 +162,17 @@
 
  };
 
- export default reactComponentMethods;
+ const staticProperties = {
+   contextTypes: {
+     flux: PropTypes.instanceOf(Flux),
+   },
+
+   childContextTypes: {
+     flux: PropTypes.instanceOf(Flux),
+   },
+ };
+
+ export { instanceMethods, staticProperties };
 
  function createStoreListener(component, store, storeStateGetter) {
    return function() {

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -176,10 +176,8 @@
 
  function createStoreListener(component, store, storeStateGetter) {
    return function() {
-     if (this.isMounted()) {
-       let state = storeStateGetter(store, this.props);
-       this.setState(state);
-     }
+     let state = storeStateGetter(store, this.props);
+     this.setState(state);
    }.bind(component);
  }
 

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -11,74 +11,74 @@
  * of `connectToStores` for details.
  */
 
- import { PropTypes } from 'react';
- import { Flux } from '../Flux';
- import assign from 'object-assign';
+import { default as React, PropTypes } from 'react';
+import { Flux } from '../Flux';
+import assign from 'object-assign';
 
- const instanceMethods = {
+const instanceMethods = {
 
-   getChildContext() {
-     let flux = this.getFlux();
+  getChildContext() {
+    const flux = this.getFlux();
 
-     if (!flux) return {};
+    if (!flux) return {};
 
-     return {
-       flux: this.getFlux()
-     };
-   },
+    return {
+      flux: this.getFlux()
+    };
+  },
 
-   getFlux() {
-     return this.props.flux || this.context.flux;
-   },
+  getFlux() {
+    return this.props.flux || this.context.flux;
+  },
 
-   initialize() {
-     this._fluxStateGetters = [];
-     this._fluxListeners = {};
-     this._fluxDidSyncStoreState = false;
-     this.flux = this.getFlux();
+  initialize() {
+    this._fluxStateGetters = [];
+    this._fluxListeners = {};
+    this._fluxDidSyncStoreState = false;
+    this.flux = this.getFlux();
 
-     if (!(this.flux instanceof Flux)) {
-       // TODO: print the actual class name here
-       throw new Error(
-         `fluxMixin: Could not find Flux instance. Ensure that your component `
-       + `has either \`this.context.flux\` or \`this.props.flux\`.`
-       );
-     }
-   },
+    if (!(this.flux instanceof Flux)) {
+      // TODO: print the actual class name here
+      throw new Error(
+        `fluxMixin: Could not find Flux instance. Ensure that your component `
+      + `has either \`this.context.flux\` or \`this.props.flux\`.`
+      );
+    }
+  },
 
-   componentWillUnmount() {
-     let flux = this.getFlux();
+  componentWillUnmount() {
+    const flux = this.getFlux();
 
-     for (let key in this._fluxListeners) {
-       if (!this._fluxListeners.hasOwnProperty(key)) continue;
+    for (let key in this._fluxListeners) {
+      if (!this._fluxListeners.hasOwnProperty(key)) continue;
 
-       let store = flux.getStore(key);
-       if (typeof store === 'undefined') continue;
+      const store = flux.getStore(key);
+      if (typeof store === 'undefined') continue;
 
-       let listener = this._fluxListeners[key];
+      const listener = this._fluxListeners[key];
 
-       store.removeListener('change', listener);
-     }
-   },
+      store.removeListener('change', listener);
+    }
+  },
 
-   componentWillReceiveProps(nextProps) {
-     this.updateStores(nextProps);
-   },
+  componentWillReceiveProps(nextProps) {
+    this.updateStores(nextProps);
+  },
 
-   updateStores(props = this.props) {
-     let state = this.getStoreState(props);
-     this.setState(state);
-   },
+  updateStores(props = this.props) {
+    const state = this.getStoreState(props);
+    this.setState(state);
+  },
 
-   getStoreState(props = this.props) {
-     return this._fluxStateGetters.reduce(
-       (result, stateGetter) => {
-         const { getter, stores } = stateGetter;
-         const stateFromStores = getter(stores, props);
-         return assign(result, stateFromStores);
-       }, {}
-     );
-   },
+  getStoreState(props = this.props) {
+    return this._fluxStateGetters.reduce(
+      (result, stateGetter) => {
+        const { getter, stores } = stateGetter;
+        const stateFromStores = getter(stores, props);
+        return assign(result, stateFromStores);
+      }, {}
+    );
+  },
 
    /**
     * Connect component to stores, get the combined initial state, and
@@ -106,88 +106,96 @@
     * @type {string|array|object} stateGetterMap - map of keys to getters
     * @returns {object} Combined initial state of stores
     */
-   connectToStores(stateGetterMap = {}, stateGetter = null) {
-     let flux = this.getFlux();
+  connectToStores(stateGetterMap = {}, stateGetter = null) {
+    const flux = this.getFlux();
 
-     let getStore = (key) => {
-       let store = flux.getStore(key);
+    const getStore = (key) => {
+      const store = flux.getStore(key);
 
-       if (typeof store === 'undefined') {
-         throw new Error(
-           `connectToStores(): Store with key '${key}' does not exist.`
-         );
-       }
+      if (typeof store === 'undefined') {
+        throw new Error(
+          `connectToStores(): Store with key '${key}' does not exist.`
+        );
+      }
 
-       return store;
-     };
+      return store;
+    };
 
-     if (typeof stateGetterMap === 'string') {
-       let key = stateGetterMap;
-       let store = getStore(key);
-       let getter = stateGetter || defaultStateGetter;
+    if (typeof stateGetterMap === 'string') {
+      const key = stateGetterMap;
+      const store = getStore(key);
+      const getter = stateGetter || defaultStateGetter;
 
-       this._fluxStateGetters.push({ stores: store, getter });
-       let listener = createStoreListener(this, store, getter);
+      this._fluxStateGetters.push({ stores: store, getter });
+      const listener = createStoreListener(this, store, getter);
 
-       store.addListener('change', listener);
-       this._fluxListeners[key] = listener;
-     } else if (Array.isArray(stateGetterMap)) {
-       let stores = stateGetterMap.map(getStore);
-       let getter = stateGetter || defaultReduceStateGetter;
+      store.addListener('change', listener);
+      this._fluxListeners[key] = listener;
+    } else if (Array.isArray(stateGetterMap)) {
+      const stores = stateGetterMap.map(getStore);
+      const getter = stateGetter || defaultReduceStateGetter;
 
-       this._fluxStateGetters.push({ stores, getter });
-       let listener = createStoreListener(this, stores, getter);
+      this._fluxStateGetters.push({ stores, getter });
+      const listener = createStoreListener(this, stores, getter);
 
-       stateGetterMap.forEach((key, index) => {
-         let store = stores[index];
-         store.addListener('change', listener);
-         this._fluxListeners[key] = listener;
-       });
+      stateGetterMap.forEach((key, index) => {
+        const store = stores[index];
+        store.addListener('change', listener);
+        this._fluxListeners[key] = listener;
+      });
 
-     } else {
+    } else {
        for (let key in stateGetterMap) {
-         let store = getStore(key);
-         let getter = stateGetterMap[key] || defaultStateGetter;
+        const store = getStore(key);
+        const getter = stateGetterMap[key] || defaultStateGetter;
 
-         this._fluxStateGetters.push({ stores: store, getter });
-         let listener = createStoreListener(this, store, getter);
+        this._fluxStateGetters.push({ stores: store, getter });
+        const listener = createStoreListener(this, store, getter);
 
-         store.addListener('change', listener);
-         this._fluxListeners[key] = listener;
-       }
-     }
+        store.addListener('change', listener);
+        this._fluxListeners[key] = listener;
+      }
+    }
 
-     return this.getStoreState();
-   }
+    return this.getStoreState();
+  }
 
- };
+};
 
- const staticProperties = {
-   contextTypes: {
-     flux: PropTypes.instanceOf(Flux),
-   },
+const staticProperties = {
+  contextTypes: {
+    flux: PropTypes.instanceOf(Flux),
+  },
 
-   childContextTypes: {
-     flux: PropTypes.instanceOf(Flux),
-   },
- };
+  childContextTypes: {
+    flux: PropTypes.instanceOf(Flux),
+  },
 
- export { instanceMethods, staticProperties };
+  propTypes: {
+    connectToStores: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.arrayOf(React.PropTypes.string),
+      React.PropTypes.func,
+    ])
+  },
+};
 
- function createStoreListener(component, store, storeStateGetter) {
-   return function() {
-     let state = storeStateGetter(store, this.props);
-     this.setState(state);
-   }.bind(component);
- }
+export { instanceMethods, staticProperties };
 
- function defaultStateGetter(store) {
-   return store.state;
- }
+function createStoreListener(component, store, storeStateGetter) {
+  return function() {
+    const state = storeStateGetter(store, this.props);
+    this.setState(state);
+  }.bind(component);
+}
 
- function defaultReduceStateGetter(stores) {
-   return stores.reduce(
-     (result, store) => assign(result, store.state),
-     {}
-   );
- }
+function defaultStateGetter(store) {
+  return store.state;
+}
+
+function defaultReduceStateGetter(stores) {
+  return stores.reduce(
+    (result, store) => assign(result, store.state),
+    {}
+  );
+}


### PR DESCRIPTION
This PR is to track implementation of something like the functional API proposed by @gaearon's gist. https://gist.github.com/gaearon/b0c060edf413fe23db0a

- [x] Extract component methods from fluxMixin and move them into their own separate module: reactComponentMethods.
- [x] Re-implement fluxMixin using reactComponentMethods.
- [x] Re-implement FluxComponent using reactComponentMethods.
- [x] Add `render` prop to FluxComponent

I have a few concerns about this last one, but will take a crack at it and see if it makes sense:

- [x] ~~Create functional (non-component) form of `connectToStores()`. Returns a renderable to be used inside a component's `render()` method. (First example in @gaearon's gist.) I really liked this when I first saw it but I have a few concerns that are hard to articulate here. I'll report back soon.~~ Never mind. See below.