### PR TITLE
Allow FluxComponent DOM element to be customized

### DIFF
--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -72,7 +72,7 @@ class FluxComponent extends React.Component {
   }
 
   getChildProps() {
-    const { children, render, connectToStores, flux, ...extraProps } = this.props;
+    const { children, render, connectToStores, flux, html, ...extraProps } = this.props;
 
     return assign(
       { flux: this.getFlux() },
@@ -82,7 +82,7 @@ class FluxComponent extends React.Component {
   }
 
   render() {
-    const { children, render } = this.props;
+    const { children, render, html = {} } = this.props;
 
     if (typeof render === 'function') {
       return render(this.getChildProps(), this.getFlux());
@@ -94,7 +94,8 @@ class FluxComponent extends React.Component {
       const child = children;
       return this.wrapChild(child);
     } else {
-      return <span>{React.Children.map(children, this.wrapChild)}</span>;
+      const { tagName = 'span', ...htmlProps } = html;
+      return React.createElement(tagName, htmlProps, React.Children.map(children, this.wrapChild));
     }
   }
 }

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -233,4 +233,32 @@ describe('FluxComponent', () => {
     expect(div.props.yay).to.equal('baz');
   });
 
+  it('allows the component wrapper element to be customized', () => {
+    const flux = new Flux();
+
+    const tree = TestUtils.renderIntoDocument(
+      <FluxComponent
+        flux={flux}>
+        <FluxComponent
+          html={
+            {
+              tagName: 'div',
+              className: 'my-class-name',
+              id: 'some-div'
+            }
+          }>
+          <h1>Header 1</h1>
+          <h2>Header 2</h2>
+          <h3>Header 3</h3>
+        </FluxComponent>
+      </FluxComponent>
+    );
+
+    const div = TestUtils.findRenderedDOMComponentWithTag(tree, 'div');
+    expect(div.props.className).to.equal('my-class-name');
+
+    const divDOM = React.findDOMNode(div);
+    expect(divDOM.className).to.equal('my-class-name');
+    expect(divDOM.id).to.equal('some-div');
+  });
 });


### PR DESCRIPTION
One hangup I've had when starting to use flummox is that the `span` elements that are generated can sometimes make layout difficult (say, when using flexbox). For example, doing this gets messy, as the subcomponents do not get the flux props since the aren't direct children:

```html
<FluxContainer connectToStores="test">
  <div className="flex-container">
    <SomeOtherComponent />
    <YetOtherComponent />
    <OneOtherComponent />
  </div>
</FluxContainer>
```

This PR allows the DOM element generated by FluxContainer to be modified like so:

```html
<FluxContainer 
  html={{ tagName: 'div', className: 'flex-container' }}
  connectToStores="test"
>
  <SomeOtherComponent />
  <YetOtherComponent />
  <OneOtherComponent />
</FluxContainer>
```

It's all optional, but allows some flexibility in using the FluxContainer without needing to resort to another wrapper element or extra markup.

Would be glad to contribute docs for this, but wanted to run it up the flagpole first to see if you think this is worthwhile, I totally understand if not :smile: 