### PR TITLE
FluxComponent stateGetter prop

### DIFF
--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -53,13 +53,7 @@ import assign from 'object-assign';
 
 const FluxComponentPropTypes = {
   render: React.PropTypes.func,
-  connectToStores: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.arrayOf(React.PropTypes.string),
-    React.PropTypes.object
-  ]),
   stateGetter: React.PropTypes.func,
-  flux: React.PropTypes.object
 };
 
 class FluxComponent extends React.Component {
@@ -116,7 +110,6 @@ assign(
 );
 
 assign(FluxComponent, staticProperties);
-
-FluxComponent.propTypes = FluxComponentPropTypes;
+assign(FluxComponent.propTypes, FluxComponentPropTypes);
 
 export default FluxComponent;

--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -83,7 +83,7 @@ class FluxComponent extends React.Component {
   }
 
   getChildProps() {
-    const { children, render, connectToStores, flux, ...extraProps } = this.props;
+    const { children, render, connectToStores, stateGetter, flux, ...extraProps } = this.props;
 
     return assign(
       { flux: this.getFlux() },

--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -51,13 +51,24 @@ import React from 'react';
 import { instanceMethods, staticProperties } from './reactComponentMethods';
 import assign from 'object-assign';
 
+const FluxComponentPropTypes = {
+  render: React.PropTypes.func,
+  connectToStores: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.arrayOf(React.PropTypes.string),
+    React.PropTypes.object
+  ]),
+  stateGetter: React.PropTypes.func,
+  flux: React.PropTypes.object
+};
+
 class FluxComponent extends React.Component {
   constructor(props, context) {
     super(props, context);
 
     this.initialize();
 
-    this.state = this.connectToStores(props.connectToStores);
+    this.state = this.connectToStores(props.connectToStores, props.stateGetter);
 
     this.wrapChild = this.wrapChild.bind(this);
   }
@@ -105,5 +116,7 @@ assign(
 );
 
 assign(FluxComponent, staticProperties);
+
+FluxComponent.propTypes = FluxComponentPropTypes;
 
 export default FluxComponent;

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -5,6 +5,7 @@ import React from 'react/addons';
 const { TestUtils } = React.addons;
 
 import FluxComponent from '../FluxComponent';
+import sinon from 'sinon';
 
 describe('FluxComponent', () => {
 
@@ -115,6 +116,18 @@ describe('FluxComponent', () => {
     expect(component.state.something).to.deep.equal('something good');
     actions.getSomething('something else');
     expect(component.state.something).to.deep.equal('something else');
+  });
+
+  it('passes stateGetter prop to reactComponentMethod connectToStores()', () => {
+    const flux = new Flux();
+    const actions = flux.getActions('test');
+    const stateGetter = sinon.stub().returns({ fiz: 'bin' });
+
+    const component = TestUtils.renderIntoDocument(
+      <FluxComponent flux={flux} connectToStores="test" stateGetter={stateGetter} />
+    );
+
+    expect(component.state.fiz).to.equal('bin');
   });
 
   it('injects children with flux prop', () => {

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -165,11 +165,18 @@ describe('FluxComponent', () => {
 
   it('injects children with any extra props', () => {
     const flux = new Flux();
+    const stateGetter = () => {};
 
+    // Pass all possible PropTypes to ensure only extra props
+    // are injected.
     const tree = TestUtils.renderIntoDocument(
-      <FluxComponent flux={flux} extraProp="hello">
-        <div />
-      </FluxComponent>
+      <FluxComponent
+        flux={flux}
+        connectToStores="test"
+        stateGetter={stateGetter}
+        extraProp="hello"
+        render={(props) => <div {...props} />}
+      />
     );
 
     const div = TestUtils.findRenderedDOMComponentWithTag(tree, 'div');

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -169,11 +169,12 @@ const staticProperties = {
   },
 
   propTypes: {
-    connectToStores: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.arrayOf(React.PropTypes.string),
-      React.PropTypes.func,
-    ])
+    connectToStores: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.object
+    ]),
+    flux: PropTypes.instanceOf(Flux)
   },
 };
 


### PR DESCRIPTION
This PR addresses #72:
- add `stateGetter` prop for `connectToStores`.
- added PropTypes specific to `FluxComponent`
- update connectToStores PropType to use `PropTypes.object` instead of `React.PropTypes.func`

I also updated the `injects children with any extra props` test to pass all possible props to the `FluxComponent`, this validates that only extra props are passed to the child.