### PR TITLE
Passing actionArgs to failure handler (Attempt #2)

### DIFF
--- a/src/Flux.js
+++ b/src/Flux.js
@@ -123,6 +123,7 @@ export default class Flux extends EventEmitter {
           this._dispatch({
             actionId,
             error,
+            actionArgs: actionArgs,
             async: 'failure',
           });
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -130,7 +130,7 @@ export default class Store extends EventEmitter {
           return;
         case 'failure':
           if (typeof _asyncHandler === 'function') {
-            this._performHandler(_asyncHandler, error);
+            this._performHandler.apply(this, [_asyncHandler].concat(error).concat(actionArgs));
           }
           return;
         case 'success':

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -252,20 +252,23 @@ describe('Flux', () => {
       const dispatch = sinon.spy();
       flux.dispatcher = { dispatch };
       const actionId = 'actionId';
+      const actionArgs = {};
 
       const error = new Error('error');
 
-      await expect(flux.dispatchAsync(actionId, Promise.reject(error)))
+      await expect(flux.dispatchAsync(actionId, Promise.reject(error), actionArgs))
         .to.be.rejected;
 
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.firstCall.args[0]).to.deep.equal({
         actionId,
+        actionArgs,
         async: 'begin',
       });
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         actionId,
         error,
+        actionArgs,
         async: 'failure'
       });
     });


### PR DESCRIPTION
(Attempt #2)

Here's a PR that passes the action's arguments through to the failure handler, which allows for optimistic rendering reverts. I'm still curious about other techniques for this sort of thing though.