### PR TITLE
typo fix

### DIFF
--- a/docs/api/FluxComponent.md
+++ b/docs/api/FluxComponent.md
@@ -7,14 +7,14 @@ Access the Flux instance and subscribe to store updates. Uses [FluxMixin](FluxMi
 
 
 ```js
-<FluxComponent connectToStores={{
+<FluxComponent flux={flux} connectToStores={{
   posts: store => ({
     post: store.getPost(this.props.post.id),
   }),
   comments: store => ({
     comments: store.getCommentsForPost(this.props.post.id),
   })
-}}>
+>
   <InnerComponent />
 </FluxComponent>
 ```


### PR DESCRIPTION
last `}}` seem like typo (checked on my example). I also added flux because looks like it's needed here.