### PR TITLE
Docs: don't concatenate object in `console.log()`

### DIFF
--- a/docs/api/Flux.md
+++ b/docs/api/Flux.md
@@ -38,7 +38,7 @@ Like Stores, Flux instances are EventEmitters. A `dispatch` event is emitted on 
 
 ```js
 flux.addListener('dispatch', payload => {
-  console.log('Dispatch: ' + payload);
+  console.log('Dispatch: ', payload);
 });
 ```
 


### PR DESCRIPTION
`[object Object]` doesn't help much ;)