### PR TITLE
make action dispatching safe

### DIFF
--- a/src/Flux.js
+++ b/src/Flux.js
@@ -137,8 +137,16 @@ export default class Flux extends EventEmitter {
   }
 
   _dispatch(payload) {
-    this.dispatcher.dispatch(payload);
-    this.emit('dispatch', payload);
+    if (!this.dispatcher.isDispatching()) {
+      this.dispatcher.dispatch(payload);
+      this.emit('dispatch', payload);
+    }
+    else {
+      setTimeout(() => {
+        this.dispatcher.dispatch(payload);
+        this.emit('dispatch', payload);
+      }, 0);
+    }
   }
 
   waitFor(tokensOrStores) {

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -152,7 +152,7 @@ describe('Flux', () => {
     it('delegates to dispatcher', () => {
       const flux = new Flux();
       const dispatch = sinon.spy();
-      flux.dispatcher = { dispatch };
+      flux.dispatcher = { dispatch, isDispatching: function() {return false;} };
       const actionId = 'actionId';
 
       flux.dispatch(actionId, 'foobar');
@@ -186,7 +186,7 @@ describe('Flux', () => {
     it('delegates to dispatcher', async function() {
       const flux = new Flux();
       const dispatch = sinon.spy();
-      flux.dispatcher = { dispatch };
+      flux.dispatcher = { dispatch, isDispatching: function() {return false;} };
       const actionId = 'actionId';
 
       await flux.dispatchAsync(actionId, Promise.resolve('foobar'));
@@ -228,7 +228,7 @@ describe('Flux', () => {
     it('resolves to value of given promise', done => {
       const flux = new Flux();
       const dispatch = sinon.spy();
-      flux.dispatcher = { dispatch };
+      flux.dispatcher = { dispatch, isDispatching: function() {return false;} };
       const actionId = 'actionId';
 
       expect(flux.dispatchAsync(actionId, Promise.resolve('foobar')))
@@ -239,7 +239,7 @@ describe('Flux', () => {
     it('rejects with error if promise rejects', done => {
       const flux = new Flux();
       const dispatch = sinon.spy();
-      flux.dispatcher = { dispatch };
+      flux.dispatcher = { dispatch, isDispatching: function() {return false;} };
       const actionId = 'actionId';
 
       expect(flux.dispatchAsync(actionId, Promise.reject(new Error('error'))))
@@ -250,7 +250,7 @@ describe('Flux', () => {
     it('dispatches with error if promise rejects', async function() {
       const flux = new Flux();
       const dispatch = sinon.spy();
-      flux.dispatcher = { dispatch };
+      flux.dispatcher = { dispatch, isDispatching: function() {return false;} };
       const actionId = 'actionId';
 
       const error = new Error('error');


### PR DESCRIPTION
I'd like to ask for some consideration to changing the dispatch action to make it safer.  I keep finding myself in situations where I need to fire additional actions in the middle of another action.  I find that in almost all cases my intended desire is to have the actions queue up to run after the current action, but dispatch doesn't allow that.  If I call the action I get the dreaded error that I cannot dispatch in the middle of another dispatch.  I'm ok with why this is not allowed, but I'd like for flummox to allow me to fire off those actions without causing massive refactoring in my other code to work around this limitation.  It seems that a simple change, such as what I did here, could easily allow for this to happen.  

One option, that I took here, is just to say that if I am dispatching while another action is in process it just delays the action by using a setTimeout.  This guarantees that the current action will complete before firing the next action.  It's a sort of natural queuing without any additional work.  The code is very simple and straightforward.  It doesn't affect how the code has been working all along, so no current user code will be affected.  If you aren't firing an action in the middle of another action the setTimeout is not used, so there's no slowdown.

Another option would be to maintain an action queue that could stack up actions, which would be fired in sequence one after another as each finishes.  Again, I'd like flummox to hide the implementation details from me so that I don't have to worry about whether I'm inside an action or not.

If you have any other suggestions on how this could be better accomplished I'd be appreciative to hearing it.