### PR TITLE
Add --harmony flag to start Koa properly

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "main": "lib/app.js",
   "scripts": {
     "prestart": "make fast-build",
-    "start": "node lib/server"
+    "start": "node --harmony lib/server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When trying to run the docs app with `npm start`, this error happens: 

    ...flummox/docs/node_modules/koa/lib/application.js:179
    function *respond(next) {
         ^
    SyntaxError: Unexpected token *

This seems to be caused by Koa needing the harmony flag. 
Issue: https://github.com/koajs/koa/issues/179
As stated here too:  https://github.com/koajs/koa#installation