### PR TITLE
Do not return rejected promise

### DIFF
--- a/src/Flux.js
+++ b/src/Flux.js
@@ -140,8 +140,6 @@ export default class Flux extends EventEmitter {
             error,
             async: 'failure',
           });
-
-          return Promise.reject(error);
         }
       )
       .catch(error => {


### PR DESCRIPTION
Doing so will lead to a nasty little `Uncaught (in promise)` error in chrome.