### PR TITLE
Add missing `extends` to last example

### DIFF
--- a/docs/docs/guides/why-flux-component-is-better-than-flux-mixin.md
+++ b/docs/docs/guides/why-flux-component-is-better-than-flux-mixin.md
@@ -146,7 +146,7 @@ class BlogPostPage extends React.Component {
 The state fetched by `connectToStores()` is transferred to the children of FluxComponent. If this auto-magic prop passing feels weird, or if you want direct control over rendering, you can pass a custom render function instead:
 
 ```js
-class BlogPostPage React.Component {
+class BlogPostPage extends React.Component {
   render() {
     <div>
       <SiteNavigation />


### PR DESCRIPTION
Just a tiny thing I noticed while reading the docs.