### PR TITLE
Correction for https://github.com/acdlite/flummox/pull/165

### DIFF
--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -61,7 +61,7 @@ class FluxComponent extends React.Component {
   }
 
   wrapChild(child) {
-    return React.addons.cloneWithProps(
+    return React.addons.cloneElement(
       child,
       this.getChildProps()
     );

--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -61,7 +61,7 @@ class FluxComponent extends React.Component {
   }
 
   wrapChild(child) {
-    return React.addons.cloneElement(
+    return React.cloneElement(
       child,
       this.getChildProps()
     );


### PR DESCRIPTION
With this, only one test fails, the `allows for FluxComponents through the tree via context`. I'm not sure exactly why yet :-)
