### PR TITLE
Fixed links in guides to work both on GitHub and gh-pages site

### DIFF
--- a/docs/docs/guides/quick-start.md
+++ b/docs/docs/guides/quick-start.md
@@ -179,6 +179,6 @@ class MessagesView extends React.Component {
 
 ```
 
-Read more in the [React integration guide](react-integration).
+Read more in the [React integration guide](react-integration.md).
 
 And there you go! I hope this guide was helpful.

--- a/docs/docs/guides/react-integration.md
+++ b/docs/docs/guides/react-integration.md
@@ -1,6 +1,6 @@
 # React integration guide
 
-If you're using Flummox, you're probably also using React. To make React integration incredibly simple, Flummox comes with some optional goodies: [FluxComponent](/flummox/docs/api/fluxcomponent) and [fluxMixin](/flummox/docs/api/fluxmixin). Both have essentially the same functionality — in fact, the component is mostly just a wrapper around the mixin. However, in the spirit of React, the component form is preferred. (Read more about [why FluxComponent is preferred](why-flux-component-is-better-than-flux-mixin).)
+If you're using Flummox, you're probably also using React. To make React integration incredibly simple, Flummox comes with some optional goodies: [FluxComponent](../api/fluxcomponent.md) and [fluxMixin](../api/fluxmixin.md). Both have essentially the same functionality — in fact, the component is mostly just a wrapper around the mixin. However, in the spirit of React, the component form is preferred. (Read more about [why FluxComponent is preferred](why-flux-component-is-better-than-flux-mixin.md).)
 
 ```js
 import FluxComponent from 'flummox/component';
@@ -100,11 +100,11 @@ So, in just a few short lines, we can specify the initialization logic, update l
 </FluxComponent>
 ```
 
-In this example, InnerComponent has props `post` and `comments`. If this auto-magic prop passing feels weird, or if you want direct control over rendering, you can pass a custom render function instead. Refer to the [FluxComponent](/flummox/docs/api/fluxcomponent) docs for more information.
+In this example, InnerComponent has props `post` and `comments`. If this auto-magic prop passing feels weird, or if you want direct control over rendering, you can pass a custom render function instead. Refer to the [FluxComponent](../api/fluxcomponent.md) docs for more information.
 
 ## Using fluxMixin
 
-**tl;dr** Just use FluxComponent. (Unless you don't want to. Up to you.) Read a longer explanation for [why FluxComponent is preferred](why-flux-component-is-better-than-flux-mixin).
+**tl;dr** Just use FluxComponent. (Unless you don't want to. Up to you.) Read a longer explanation for [why FluxComponent is preferred](why-flux-component-is-better-than-flux-mixin.md).
 
 ***
 

--- a/docs/docs/guides/why-flux-component-is-better-than-flux-mixin.md
+++ b/docs/docs/guides/why-flux-component-is-better-than-flux-mixin.md
@@ -1,7 +1,7 @@
 Why FluxComponent > fluxMixin
 =============================
 
-In the [React integration guide](react-integration), I suggest that using [FluxComponent](/flummox/docs/api/fluxcomponent) is better than using [fluxMixin](/flummox/docs/api/fluxmixin), even though they do essentially the same thing. A few people have told me they like the mixin form more, so allow me to explain.
+In the [React integration guide](react-integration.md), I suggest that using [FluxComponent](../api/fluxcomponent.md) is better than using [fluxMixin](../api/fluxmixin.md), even though they do essentially the same thing. A few people have told me they like the mixin form more, so allow me to explain.
 
 My argument can be broken down into three basic points. Note that these aren't my original ideas, nor are they unique to Flummox — they are the "React Way":
 


### PR DESCRIPTION
Note: Absolute links starting with `/flummox/docs/...` don't work in docs on GitHub. You will end up with links like `https://github.com/acdlite/flummox/blob/master/flummox/docs/api/fluxcomponent`. Also the `.md` extension is needed for GitHub.

I have replaced them with relative links so the links work both on GitHub and in the isomorphic docs app on gh-pages. However the folder structure differs for index files so this fix does not work there.

It would be great to make the isomorphic docs app consistent with how GitHub deals with links. There are still blog posts that point directly to the GH version of the docs (like this https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750),