### PR TITLE
React-native component

### DIFF
--- a/component.js
+++ b/component.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/addons/FluxComponent');

--- a/component/native.js
+++ b/component/native.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/addons/component/native');

--- a/component/web.js
+++ b/component/web.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/addons/component/web');

--- a/src/addons/component/__tests__/FluxComponent-test.js
+++ b/src/addons/component/__tests__/FluxComponent-test.js
@@ -1,10 +1,10 @@
-import { Flummox, Store, Actions } from '../../Flux';
-import addContext from './addContext';
+import { Flummox, Store, Actions } from '../../../Flux';
+import addContext from '../../__tests__/addContext';
 
 import React from 'react/addons';
 const { TestUtils } = React.addons;
 
-import FluxComponent from '../FluxComponent';
+import FluxComponent from '../web';
 import sinon from 'sinon';
 
 describe('FluxComponent', () => {

--- a/src/addons/component/native.js
+++ b/src/addons/component/native.js
@@ -1,5 +1,5 @@
 /**
- * Flux Component
+ * Flux Native Component
  *
  * Component interface to reactComponentMethods module.
  *
@@ -45,9 +45,11 @@
  * and props that sync with each of the state keys of fooStore.
  */
 
-import React from 'react/addons';
-import { instanceMethods, staticProperties } from './reactComponentMethods';
+import React from 'react-native';
+import { instanceMethods, staticProperties } from '../reactComponentMethods';
 import assign from 'object-assign';
+
+let { PropTypes, View } = React;
 
 class FluxComponent extends React.Component {
   constructor(props, context) {
@@ -72,28 +74,22 @@ class FluxComponent extends React.Component {
       children,
       render,
       connectToStores,
-      injectActions,
       stateGetter,
       flux,
       ...extraProps } = this.props;
 
     return assign(
       { flux: this.getFlux() }, // TODO: remove in next major version
-      this.collectActions(injectActions),
       this.state,
       extraProps
     );
   }
 
   render() {
-    const { children, render, injectActions } = this.props;
+    const { children, render } = this.props;
 
     if (typeof render === 'function') {
-      return render(
-        this.state,
-        this.collectActions(injectActions),
-        this.getFlux()
-      );
+      return render(this.getChildProps(), this.getFlux());
     }
 
     if (!children) return null;
@@ -102,7 +98,7 @@ class FluxComponent extends React.Component {
       const child = children;
       return this.wrapChild(child);
     } else {
-      return <span>{React.Children.map(children, this.wrapChild)}</span>;
+      return <View>{React.Children.map(children, this.wrapChild)}</View>;
     }
   }
 }
@@ -112,6 +108,6 @@ assign(
   instanceMethods
 );
 
-assign(FluxComponent, staticProperties);
+assign(FluxComponent, staticProperties(PropTypes));
 
 export default FluxComponent;

--- a/src/addons/component/web.js
+++ b/src/addons/component/web.js
@@ -1,0 +1,117 @@
+/**
+ * Flux Component
+ *
+ * Component interface to reactComponentMethods module.
+ *
+ * Children of FluxComponent are given access to the flux instance via
+ * `context.flux`. Use this near the top of your app hierarchy and all children
+ * will have easy access to the flux instance (including, of course, other
+ * Flux components!):
+ *
+ * <FluxComponent flux={flux}>
+ *    ...the rest of your app
+ * </FluxComponent>
+ *
+ * Now any child can access the flux instance again like this:
+ *
+ * <FluxComponent>
+ *    ...children
+ * </FluxComponent>
+ *
+ * We don't need the flux prop this time because flux is already part of
+ * the context.
+ *
+ * Additionally, immediate children are given a `flux` prop.
+ *
+ * The component has an optional prop `connectToStores`, which is passed to
+ * `this.connectToStores` and used to set the initial state. The component's
+ * state is injected as props to the child components.
+ *
+ * The practical upshot of all this is that fluxMixin, state changes, and
+ * context are now simply implementation details. Among other things, this means
+ * you can write your components as plain ES6 classes. Here's an example:
+ *
+ * class ParentComponent extends React.Component {
+ *
+ *   render() {
+ *     <FluxComponent connectToStores="fooStore">
+ *       <ChildComponent />
+ *     </FluxComponent>
+ *   }
+ *
+ * }
+ *
+ * ChildComponent in this example has prop `flux` containing the flux instance,
+ * and props that sync with each of the state keys of fooStore.
+ */
+
+import { default as React, PropTypes } from 'react/addons';
+import { instanceMethods, staticProperties } from '../reactComponentMethods';
+import assign from 'object-assign';
+
+class FluxComponent extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.initialize();
+
+    this.state = this.connectToStores(props.connectToStores, props.stateGetter);
+
+    this.wrapChild = this.wrapChild.bind(this);
+  }
+
+  wrapChild(child) {
+    return React.addons.cloneWithProps(
+      child,
+      this.getChildProps()
+    );
+  }
+
+  getChildProps() {
+    const {
+      children,
+      render,
+      connectToStores,
+      injectActions,
+      stateGetter,
+      flux,
+      ...extraProps } = this.props;
+
+    return assign(
+      { flux: this.getFlux() }, // TODO: remove in next major version
+      this.collectActions(injectActions),
+      this.state,
+      extraProps
+    );
+  }
+
+  render() {
+    const { children, render, injectActions } = this.props;
+
+    if (typeof render === 'function') {
+      return render(
+        this.state,
+        this.collectActions(injectActions),
+        this.getFlux()
+      );
+    }
+
+    if (!children) return null;
+
+    if (!Array.isArray(children)) {
+      const child = children;
+      return this.wrapChild(child);
+    } else {
+      return <span>{React.Children.map(children, this.wrapChild)}</span>;
+    }
+  }
+}
+
+assign(
+  FluxComponent.prototype,
+  instanceMethods
+);
+
+assign(FluxComponent, staticProperties(PropTypes));
+
+export default FluxComponent;

--- a/src/addons/connectToStores.js
+++ b/src/addons/connectToStores.js
@@ -2,7 +2,7 @@
  * Higher-order component form of connectToStores
  */
 
-import React from 'react';
+import { default as React, PropTypes } from 'react';
 import { instanceMethods, staticProperties } from './reactComponentMethods';
 import assign from 'object-assign';
 
@@ -26,7 +26,7 @@ export default (BaseComponent, stores, stateGetter) => {
     instanceMethods
   );
 
-  assign(ConnectedComponent, staticProperties);
+  assign(ConnectedComponent, staticProperties(PropTypes));
 
   return ConnectedComponent;
 };

--- a/src/addons/fluxMixin.js
+++ b/src/addons/fluxMixin.js
@@ -36,6 +36,6 @@ export default function fluxMixin(...args) {
   return assign(
     { getInitialState },
     instanceMethods,
-    staticProperties
+    staticProperties(PropTypes)
   );
 };

--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -11,7 +11,6 @@
  * of `connectToStores` for details.
  */
 
-import { default as React, PropTypes } from 'react';
 import { Flux } from '../Flux';
 import assign from 'object-assign';
 
@@ -202,26 +201,28 @@ const instanceMethods = {
   }
 };
 
-const staticProperties = {
-  contextTypes: {
-    flux: PropTypes.instanceOf(Flux),
-  },
+function staticProperties(PropTypes) {
+  return {
+    contextTypes: {
+      flux: PropTypes.instanceOf(Flux),
+    },
 
-  childContextTypes: {
-    flux: PropTypes.instanceOf(Flux),
-  },
+    childContextTypes: {
+      flux: PropTypes.instanceOf(Flux),
+    },
 
-  propTypes: {
-    connectToStores: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.object
-    ]),
-    flux: PropTypes.instanceOf(Flux),
-    render: React.PropTypes.func,
-    stateGetter: React.PropTypes.func,
-  },
-};
+    propTypes: {
+      connectToStores: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.object
+      ]),
+      flux: PropTypes.instanceOf(Flux),
+      render: PropTypes.func,
+      stateGetter: PropTypes.func,
+    }
+  };
+}
 
 export { instanceMethods, staticProperties };
 


### PR DESCRIPTION
Hi,

I've tweaked `FluxComponent` to give us a native version of it for use with `react-native`.

Going forward, I think that #161 decorator's approach could be used to simplify the codebase even more.

To allow for more flexibility going forward, `FluxComponent` was renamed to `flummox/component/web` and the native one lives in `flummox/component/native`. Also, testing for the native component is missing - it's a tricky area (that should be tackled soon anyway).

An alternative implementation would be to create a function that receives both, `React` and the element to use as a container `div`, `View`, etc., and returns a component. I think this is a slightly cleaner approach.

BTW, thanks for flummox, it's proving very clean and nice to work with :).

Thoughts?
Darío