### PR TITLE
Typo Line 143: "Store#register" -> "Store.register"

### DIFF
--- a/docs/docs/guides/quick-start.md
+++ b/docs/docs/guides/quick-start.md
@@ -140,7 +140,7 @@ You can access a Flux instance's actions and stores using `getActions(key)` and 
 
 There's an additional method for accessing action ids: `getActionIds(key)`. This is the method we used in the MessageStore class we created above, in order to register the store's action handler. That's why we're passing our Flux instance to the constructor of MessageStore. To reiterate, this isn't a requirement; just a recommended pattern.
 
-Each Flux instance comes with its own dispatcher. Like constants, the dispatcher is treated as an implementation detail. The closest you'll come to interacting with it in most cases is the `Store#register(actionId, handler)` method discussed above. However, if you want to access the dispatcher directly, you can reference the `dispatcher` property of the Flux instance.
+Each Flux instance comes with its own dispatcher. Like constants, the dispatcher is treated as an implementation detail. The closest you'll come to interacting with it in most cases is the `Store.register(actionId, handler)` method discussed above. However, if you want to access the dispatcher directly, you can reference the `dispatcher` property of the Flux instance.
 
 So, now we have an AppFlux class that encapsulates our entire Flux set-up! Now we just create an instance:
 


### PR DESCRIPTION
I was confused for a minute, so I fixed a "#" to a "." on line 143. Maybe this isn't a typo, and refers to the method on the class instance, but I figured I'd point it out to be sure. Thanks for the great documentation!