### PR TITLE
If clicking on link with middle mouse click don't override default behaviour

### DIFF
--- a/docs/src/client/app.js
+++ b/docs/src/client/app.js
@@ -43,6 +43,9 @@ document.onclick = event => {
 
   if (!href) return;
 
+  // if middle click then don't override default click behaviour
+  if (event.which === 2) return;
+
   const resolvedHref = url.resolve(window.location.href, href);
   const { host, path } = url.parse(resolvedHref);
 


### PR DESCRIPTION
I'm a bit of a taboholic and my preferred way of opening new tabs is to use middle click. This PR just ensures that the docs allow me continue my habit :smile: 