### PR TITLE
Import React with addons to use cloneWithProps

### DIFF
--- a/src/addons/react.js
+++ b/src/addons/react.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react/addons';
 
 import createFluxComponent from './FluxComponent';
 import createConnect from './connect';


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'cloneWithProps' of undefined` error in [FluxComponent.wrapChild](https://github.com/acdlite/flummox/blob/master/src/addons/FluxComponent.js#L69) method.