### PR TITLE
Fix: HOC store state gets overwritten on multiple listeners

### DIFF
--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -249,7 +249,7 @@ function createStoreListener(component, store, storeStateGetter) {
   return function() {
     const state = storeStateGetter(store, this.props);
     this.setState({
-      storeState: state
+      storeState: assign(this.state.storeState, state)
     });
   }.bind(component);
 }


### PR DESCRIPTION
Suppose HOC is connected with multiple stores using state getter maps like this:
```
<FluxComponent connectToStores={{
  foo: store => ({
    fooValue: store.getStateAsObject().fooValue
  }),
  bar: store => ({
    barValue: store.getStateAsObject().barValue
  })
}}>
  ...
</FluxComponent>
```

When `bar` store emits change event, its listener fully overwrites previous HOC state. Calculated state from `foo` store gets lost. 

This PR fixes this issue.  But it does not correctly handle cases when storeStateGetter returns a value with new keys and old keys will remain unchanged instead of being removed.

Another solution is just recalc all registered state getters on every store change, which may become compute heavy task:
```
function createStoreListener(component) {
  return function() {
    const state = this.getStoreState();
    this.setState({
      storeState: state
    });
  }.bind(component);
}
```