### PR TITLE
Browser bundle fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ watch-js:
 
 browser: $(SRC_JS)
 	mkdir -p dist
-	$(WEBPACK_CMD) src/Flux.js dist/flummox.js
-	NODE_ENV=production $(WEBPACK_CMD) src/Flux.js dist/flummox.min.js
+	$(WEBPACK_CMD) browser.js dist/flummox.js
+	NODE_ENV=production $(WEBPACK_CMD) browser.js dist/flummox.min.js
 
 .PHONY: build clean test test-cov lin fast-build js fast-js watch-js browser

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import Flummox from './src/Flux';
+import addons from './src/addons/react';
+
+const lib = {
+  ...Flummox,
+  addons: {
+    ...addons
+  }
+};
+
+export default lib;

--- a/src/Flux.js
+++ b/src/Flux.js
@@ -326,11 +326,9 @@ function getValues(object) {
   return values;
 }
 
-const Flummox = Flux;
-
-export {
+export default {
   Flux,
-  Flummox,
+  Flummox: Flux,
   Store,
   Actions,
 };

--- a/src/addons/react-native.js
+++ b/src/addons/react-native.js
@@ -3,5 +3,7 @@ import React, { View } from 'react-native';
 import createFluxComponent from './FluxComponent';
 import createConnect from './connect';
 
-export const FluxComponent = createFluxComponent(React, View);
-export const connect = createConnect(React);
+export default {
+  FluxComponent: createFluxComponent(React, View),
+  connect: createConnect(React)
+};

--- a/src/addons/react.js
+++ b/src/addons/react.js
@@ -3,5 +3,7 @@ import React from 'react/addons';
 import createFluxComponent from './FluxComponent';
 import createConnect from './connect';
 
-export const FluxComponent = createFluxComponent(React, 'span');
-export const connect = createConnect(React);
+export default {
+  FluxComponent: createFluxComponent(React, 'span'),
+  connect: createConnect(React)
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,10 @@ module.exports = {
     libraryTarget: 'var'
   },
 
+  externals: [{
+    "react/addons": "var React"
+  }],
+
   plugins: plugins,
 
   resolve: {


### PR DESCRIPTION
This adds `FluxComponent` and `connect` to the browser build. I've taken the liberty to convert multiple single `export` statements into a single `export default` statement, in order to be able to use the spread operator when exporting for the browser build.

/cc @acdlite 
