### PR TITLE
Remove warning when returning a string from .serialize 

### DIFF
--- a/docs/docs/api/store.md
+++ b/docs/docs/api/store.md
@@ -172,7 +172,9 @@ Static Methods
 
 ### serialize(state)
 
-If you use `Flux.serialize`, Flummox will try to call the static method `serialize` on all your stores. Flummox will pass the state object of the store to the method and expects a String
+If you use `Flux.serialize`, Flummox will try to call the static method `serialize` on all your stores. Flummox will pass the state object of the store to the method and leave it to you to return any custom serialization. Whatever you return will be bundled into an overall store object with store names as keys and whatever the various `serialize` methods return as values. This entire object is `stringified` and output in `Flux.serialize` method.
+
+If you don't have any reason for custom serialization, you can just `return state` and it will be stringified by `Flux.serialize`.
 
 ### deserialize(state)
 

--- a/src/Flux.js
+++ b/src/Flux.js
@@ -227,21 +227,9 @@ export default class Flux extends EventEmitter {
 
       if (typeof serialize !== 'function') continue;
 
-      const serializedStoreState = serialize(store.state);
+      const storeState = serialize(store.state);
 
-      if (typeof serializedStoreState !== 'string') {
-        const className = store.constructor.name;
-
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(
-            `The store with key '${key}' was not serialized because the static `
-          + `method \`${className}.serialize()\` returned a non-string with type `
-          + `'${typeof serializedStoreState}'.`
-          );
-        }
-      }
-
-      stateTree[key] = serializedStoreState;
+      stateTree[key] = storeState;
 
       if (typeof store.constructor.deserialize !== 'function') {
         const className = store.constructor.name;

--- a/src/__tests__/Flux-test.js
+++ b/src/__tests__/Flux-test.js
@@ -449,22 +449,6 @@ describe('Flux', () => {
       });
     });
 
-    it('warns if any store classes .serialize() returns a non-string', () => {
-      const flux = new Flux();
-      const warn = sinon.spy(console, 'warn');
-
-      flux.createStore('foo', createSerializableStore({}));
-      flux.serialize();
-
-      expect(warn.firstCall.args[0]).to.equal(
-        'The store with key \'foo\' was not serialized because the static '
-      + 'method `SerializableStore.serialize()` returned a non-string with '
-      + 'type \'object\'.'
-      );
-
-      console.warn.restore();
-    });
-
     it('warns and skips stores whose classes do not implement .deserialize()', () => {
       const flux = new Flux();
       const warn = sinon.spy(console, 'warn');


### PR DESCRIPTION
Remove warning when _not_ returning a string from .serialize since Flux.js serializes the combined store object. Users can still do custom serialization when needed.

Added some more explanation in the docs.

https://github.com/acdlite/flummox/issues/174
