### PR TITLE
Store handler inject state

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "eventemitter3": "~0.1.6",
     "flux": "~2.0.1",
+    "lodash": "^3.9.3",
     "object-assign": "~2.0.0",
     "uniqueid": "~0.1.0"
   }

--- a/src/Store.js
+++ b/src/Store.js
@@ -9,6 +9,7 @@
 
 import EventEmitter from 'eventemitter3';
 import assign from 'object-assign';
+import isPlainObject from 'lodash/lang/isPlainObject';
 
 export default class Store extends EventEmitter {
 
@@ -225,7 +226,7 @@ export default class Store extends EventEmitter {
           actionHandler(payload, state) :
           actionHandler(body, payload, state);
 
-        if (typeof transformedState === 'object') {
+        if (isPlainObject(transformedState)) {
           this.setState(transformedState);
         }
       }

--- a/src/Store.js
+++ b/src/Store.js
@@ -218,11 +218,13 @@ export default class Store extends EventEmitter {
 
     try {
       const allHandlers = matchedActionHandlers.concat(customMatchedActionHandlers);
-      
       // Dispatch all handlers
       for (let actionHandler of allHandlers) {
-        const state = this._pendingState || this.state;
-        const transformedState = actionHandler(state, payload);
+        const state = this._pendingState;
+        const transformedState = actionHandler.length === 2 ?
+          actionHandler(payload, state) :
+          actionHandler(body, payload, state);
+
         if (typeof transformedState === 'object') {
           this.setState(transformedState);
         }

--- a/src/Store.js
+++ b/src/Store.js
@@ -222,9 +222,7 @@ export default class Store extends EventEmitter {
       // Dispatch all handlers
       for (let actionHandler of allHandlers) {
         const state = this._pendingState;
-        const transformedState = actionHandler.length === 2 ?
-          actionHandler(payload, state) :
-          actionHandler(body, payload, state);
+        const transformedState = actionHandler(body, payload, state);
 
         if (isPlainObject(transformedState)) {
           this.setState(transformedState);

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -681,6 +681,44 @@ describe('Store', () => {
       expect(store.state.foo).to.equal('foobar');
     });
 
+    it('do not trigger a `setState` when not returning an object', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      const invalid = [
+        'testing',
+        [1, 2, 3],
+        /test/,
+        new Date(),
+        true,
+        false,
+        null
+      ];
+
+      invalid.forEach((invalidReturn) => {
+        store.registerAll(({body}, prevState) => {
+          return invalidReturn;
+        });
+      });
+
+      actions.foo('foo');
+      expect(store.state.foo).to.equal('bar');
+    });
+
     it('receive always the latest state object', () => {
       class ExampleFlux extends Flux {
         constructor() {

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -625,34 +625,6 @@ describe('Store', () => {
       actions.foo('foo');
     });
 
-    it('receive `payload` and `prevState` arguments when they accept 2 arguments', () => {
-      class ExampleFlux extends Flux {
-        constructor() {
-          super();
-          this.createActions('example', {
-            foo(something) {
-              return something;
-            }
-          });
-
-          this.createStore('example', ExampleStore);
-        }
-      }
-
-      const flux = new ExampleFlux();
-      const actions = flux.getActions('example');
-      const store = flux.getStore('example');
-
-      // using a function to inspect arguments
-      store.registerAll(function (payload, prevState) {
-        expect(arguments.length).to.equal(2);
-        expect(payload.body).to.equal('foo');
-        expect(prevState).to.equal(store._pendingState);
-      });
-
-      actions.foo('foo');
-    });
-
     it('can trigger a `setState` by returning an object', () => {
       class ExampleFlux extends Flux {
         constructor() {
@@ -671,7 +643,7 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         return {
           foo: body + prevState.foo
         };
@@ -710,7 +682,7 @@ describe('Store', () => {
       ];
 
       invalid.forEach((invalidReturn) => {
-        store.registerAll(({body}, prevState) => {
+        store.registerAll((body, payload, prevState) => {
           return invalidReturn;
         });
       });
@@ -737,13 +709,13 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         return {
           foo: body + prevState.foo
         };
       });
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         expect(prevState.foo).to.equal('foobar');
         return {
           foo: 'test' + prevState.foo
@@ -772,19 +744,19 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         return {
           foo: prevState.foo + body
         };
       });
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         return {
           foo: prevState.foo + body
         };
       });
 
-      store.registerAll(({body}, prevState) => {
+      store.registerAll((body, payload, prevState) => {
         return {
           foo: prevState.foo + 42
         };

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -596,6 +596,63 @@ describe('Store', () => {
 
   describe('action handlers', () => {
 
+    it('receive `body`, `payload` and `prevState` arguments when they accept 3 arguments', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      // using a function to inspect arguments
+      store.registerAll(function (body, payload, prevState) {
+        expect(arguments.length).to.equal(3);
+        expect(body).to.equal('foo');
+        expect(payload.body).to.equal('foo');
+        expect(prevState).to.equal(store._pendingState);
+      });
+
+      actions.foo('foo');
+    });
+
+    it('receive `payload` and `prevState` arguments when they accept 2 arguments', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      // using a function to inspect arguments
+      store.registerAll(function (payload, prevState) {
+        expect(arguments.length).to.equal(2);
+        expect(payload.body).to.equal('foo');
+        expect(prevState).to.equal(store._pendingState);
+      });
+
+      actions.foo('foo');
+    });
+
     it('can trigger a `setState` by returning an object', () => {
       class ExampleFlux extends Flux {
         constructor() {
@@ -614,9 +671,9 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll((state, {body}) => {
+      store.registerAll(({body}, prevState) => {
         return {
-          foo: body + state.foo
+          foo: body + prevState.foo
         };
       });
 
@@ -642,16 +699,16 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll((state, {body}) => {
+      store.registerAll(({body}, prevState) => {
         return {
-          foo: body + state.foo
+          foo: body + prevState.foo
         };
       });
 
-      store.registerAll((state, {body}) => {
-        expect(state.foo).to.equal('foobar');
+      store.registerAll(({body}, prevState) => {
+        expect(prevState.foo).to.equal('foobar');
         return {
-          foo: 'test' + state.foo
+          foo: 'test' + prevState.foo
         };
       });
 
@@ -677,21 +734,21 @@ describe('Store', () => {
       const actions = flux.getActions('example');
       const store = flux.getStore('example');
 
-      store.registerAll((state, {body}) => {
+      store.registerAll(({body}, prevState) => {
         return {
-          foo: state.foo + body
+          foo: prevState.foo + body
         };
       });
 
-      store.registerAll((state, {body}) => {
+      store.registerAll(({body}, prevState) => {
         return {
-          foo: state.foo + body
+          foo: prevState.foo + body
         };
       });
 
-      store.registerAll((state, {body}) => {
+      store.registerAll(({body}, prevState) => {
         return {
-          foo: state.foo + 42
+          foo: prevState.foo + 42
         };
       });
 

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -35,11 +35,11 @@ describe('Store', () => {
 
       actions.foo('do');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('do');
+      expect(handler.firstCall.args[1].body).to.equal('do');
 
       actions.foo('re');
       expect(handler.calledTwice).to.be.true;
-      expect(handler.secondCall.args[0]).to.equal('re');
+      expect(handler.secondCall.args[1].body).to.equal('re');
     });
 
     it('registers handler to respond to async action success', async () => {
@@ -65,11 +65,11 @@ describe('Store', () => {
 
       await actions.foo('do');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('do');
+      expect(handler.firstCall.args[1].body).to.equal('do');
 
       await actions.foo('re');
       expect(handler.calledTwice).to.be.true;
-      expect(handler.secondCall.args[0]).to.equal('re');
+      expect(handler.secondCall.args[1].body).to.equal('re');
     });
 
     it('ignores non-function handlers', () => {
@@ -117,7 +117,7 @@ describe('Store', () => {
 
       await actions.getBar('bar');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('bar');
+      expect(handler.firstCall.args[1].body).to.equal('bar');
 
       const begin = sinon.spy();
       const success = sinon.spy();
@@ -126,9 +126,9 @@ describe('Store', () => {
 
       await actions.getFoo('foo', true);
       expect(begin.calledOnce).to.be.true;
-      expect(begin.firstCall.args[0].async).to.equal('begin');
+      expect(begin.firstCall.args[1].async).to.equal('begin');
       expect(success.calledOnce).to.be.true;
-      expect(success.firstCall.args[0]).to.equal('foo success');
+      expect(success.firstCall.args[1].body).to.equal('foo success');
       expect(failure.called).to.be.false;
 
       await expect(actions.getFoo('bar', false)).to.be.rejected;
@@ -136,7 +136,7 @@ describe('Store', () => {
       expect(begin.calledTwice).to.be.true;
       expect(success.calledOnce).to.be.true;
       expect(failure.calledOnce).to.be.true;
-      expect(failure.firstCall.args[0]).to.equal(error);
+      expect(failure.firstCall.args[1].error).to.equal(error);
     });
 
     it('ignores non-function handlers', () => {
@@ -169,11 +169,11 @@ describe('Store', () => {
 
       actions.foo('do');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('do');
+      expect(handler.firstCall.args[1].body).to.equal('do');
 
       actions.foo('re');
       expect(handler.calledTwice).to.be.true;
-      expect(handler.secondCall.args[0]).to.equal('re');
+      expect(handler.secondCall.args[1].body).to.equal('re');
     });
 
     it('registers handler to respond to all async action successes', async () => {
@@ -199,11 +199,11 @@ describe('Store', () => {
 
       await actions.foo('do');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('do');
+      expect(handler.firstCall.args[1].body).to.equal('do');
 
       await actions.foo('re');
       expect(handler.calledTwice).to.be.true;
-      expect(handler.secondCall.args[0]).to.equal('re');
+      expect(handler.secondCall.args[1].body).to.equal('re');
     });
 
     it('ignores non-function handlers', () => {
@@ -245,7 +245,7 @@ describe('Store', () => {
 
       await actions.getBar('bar');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0]).to.equal('bar success');
+      expect(handler.firstCall.args[1].body).to.equal('bar success');
     });
 
   });
@@ -287,29 +287,29 @@ describe('Store', () => {
 
       await actions.getFoo('foo', true);
       expect(begin.calledOnce).to.be.true;
-      expect(begin.firstCall.args[0].async).to.equal('begin');
+      expect(begin.firstCall.args[1].async).to.equal('begin');
       expect(success.calledOnce).to.be.true;
-      expect(success.firstCall.args[0]).to.equal('foo success');
+      expect(success.firstCall.args[1].body).to.equal('foo success');
       expect(failure.called).to.be.false;
 
       await expect(actions.getFoo('bar', false)).to.be.rejected;
       expect(begin.calledTwice).to.be.true;
       expect(success.calledOnce).to.be.true;
       expect(failure.calledOnce).to.be.true;
-      expect(failure.firstCall.args[0]).to.equal(error);
+      expect(failure.firstCall.args[1].error).to.equal(error);
 
       await actions.getBar('foo', true);
       expect(begin.calledThrice).to.be.true;
-      expect(begin.thirdCall.args[0].async).to.equal('begin');
+      expect(begin.thirdCall.args[1].async).to.equal('begin');
       expect(success.calledTwice).to.be.true;
-      expect(success.secondCall.args[0]).to.equal('foo success');
+      expect(success.secondCall.args[1].body).to.equal('foo success');
       expect(failure.calledTwice).to.be.false;
 
       await expect(actions.getBar('bar', false)).to.be.rejected;
       expect(begin.callCount).to.equal(4);
       expect(success.calledTwice).to.be.true;
       expect(failure.calledTwice).to.be.true;
-      expect(failure.secondCall.args[0]).to.equal(error);
+      expect(failure.secondCall.args[1].error).to.equal(error);
     });
 
     it('ignores non-function handlers', () => {
@@ -345,7 +345,7 @@ describe('Store', () => {
 
       actions.foo('match!');
       expect(handler.calledOnce).to.be.true;
-      expect(handler.firstCall.args[0].body).to.equal('match!');
+      expect(handler.firstCall.args[1].body).to.equal('match!');
 
       actions.foo('not a match!');
       expect(handler.calledOnce).to.be.true;
@@ -592,6 +592,113 @@ describe('Store', () => {
       expect(listener.calledOnce).to.be.true;
       expect(store.state).to.deep.equal({ baz: 'foo' });
     });
+  });
+
+  describe('action handlers', () => {
+
+    it('can trigger a `setState` by returning an object', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      store.registerAll((state, {body}) => {
+        return {
+          foo: body + state.foo
+        };
+      });
+
+      actions.foo('foo');
+      expect(store.state.foo).to.equal('foobar');
+    });
+
+    it('receive always the latest state object', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      store.registerAll((state, {body}) => {
+        return {
+          foo: body + state.foo
+        };
+      });
+
+      store.registerAll((state, {body}) => {
+        expect(state.foo).to.equal('foobar');
+        return {
+          foo: 'test' + state.foo
+        };
+      });
+
+      actions.foo('foo');
+      expect(store.state.foo).to.equal('testfoobar');
+    });
+
+    it('`setState` calls are additive', () => {
+      class ExampleFlux extends Flux {
+        constructor() {
+          super();
+          this.createActions('example', {
+            foo(something) {
+              return something;
+            }
+          });
+
+          this.createStore('example', ExampleStore);
+        }
+      }
+
+      const flux = new ExampleFlux();
+      const actions = flux.getActions('example');
+      const store = flux.getStore('example');
+
+      store.registerAll((state, {body}) => {
+        return {
+          foo: state.foo + body
+        };
+      });
+
+      store.registerAll((state, {body}) => {
+        return {
+          foo: state.foo + body
+        };
+      });
+
+      store.registerAll((state, {body}) => {
+        return {
+          foo: state.foo + 42
+        };
+      });
+
+      actions.foo('foo');
+      expect(store.state.foo).to.equal('barfoofoo42');
+    });
+
   });
 
 });

--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -55,7 +55,8 @@ describe('Examples:', () => {
         this.state = {};
       }
 
-      handleNewMessage(content) {
+      handleNewMessage(state, {body: content}) {
+        console.log(content);
         const id = this.messageCounter++;
 
         this.setState({

--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -55,16 +55,14 @@ describe('Examples:', () => {
         this.state = {};
       }
 
-      handleNewMessage(state, {body: content}) {
-        console.log(content);
+      handleNewMessage({body: content}, state) {
         const id = this.messageCounter++;
-
-        this.setState({
+        return {
           [id]: {
             content,
             id,
-          },
-        });
+          }
+        };
       }
     }
 

--- a/src/__tests__/exampleFlux-test.js
+++ b/src/__tests__/exampleFlux-test.js
@@ -55,7 +55,7 @@ describe('Examples:', () => {
         this.state = {};
       }
 
-      handleNewMessage({body: content}, state) {
+      handleNewMessage(content, payload, state) {
         const id = this.messageCounter++;
         return {
           [id]: {

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -27,7 +27,7 @@ describe('FluxComponent', () => {
       };
     }
 
-    handleGetSomething({body: something}, state) {
+    handleGetSomething(something, payload, state) {
       return { something };
     }
   }

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -27,7 +27,7 @@ describe('FluxComponent', () => {
       };
     }
 
-    handleGetSomething(something) {
+    handleGetSomething(state, {body: something}) {
       this.setState({ something });
     }
   }

--- a/src/addons/__tests__/FluxComponent-test.js
+++ b/src/addons/__tests__/FluxComponent-test.js
@@ -27,8 +27,8 @@ describe('FluxComponent', () => {
       };
     }
 
-    handleGetSomething(state, {body: something}) {
-      this.setState({ something });
+    handleGetSomething({body: something}, state) {
+      return { something };
     }
   }
 

--- a/src/addons/__tests__/connect-test.js
+++ b/src/addons/__tests__/connect-test.js
@@ -23,8 +23,8 @@ class TestStore extends Store {
     };
   }
 
-  handleGetSomething(state, {body: something}) {
-    this.setState({ something });
+  handleGetSomething({body: something}, state) {
+    return {something};
   }
 }
 

--- a/src/addons/__tests__/connect-test.js
+++ b/src/addons/__tests__/connect-test.js
@@ -23,7 +23,7 @@ class TestStore extends Store {
     };
   }
 
-  handleGetSomething({body: something}, state) {
+  handleGetSomething(something, payload, state) {
     return {something};
   }
 }

--- a/src/addons/__tests__/connect-test.js
+++ b/src/addons/__tests__/connect-test.js
@@ -23,7 +23,7 @@ class TestStore extends Store {
     };
   }
 
-  handleGetSomething(something) {
+  handleGetSomething(state, {body: something}) {
     this.setState({ something });
   }
 }

--- a/src/addons/__tests__/reactComponentMethods-test.js
+++ b/src/addons/__tests__/reactComponentMethods-test.js
@@ -45,7 +45,7 @@ describe('fluxMixin', () => {
       };
     }
 
-    handleGetSomething({body: something}, state) {
+    handleGetSomething(something, payload, state) {
       return {something};
     }
   }

--- a/src/addons/__tests__/reactComponentMethods-test.js
+++ b/src/addons/__tests__/reactComponentMethods-test.js
@@ -45,8 +45,8 @@ describe('fluxMixin', () => {
       };
     }
 
-    handleGetSomething(state, {body: something}) {
-      this.setState({ something });
+    handleGetSomething({body: something}, state) {
+      return {something};
     }
   }
 

--- a/src/addons/__tests__/reactComponentMethods-test.js
+++ b/src/addons/__tests__/reactComponentMethods-test.js
@@ -45,7 +45,7 @@ describe('fluxMixin', () => {
       };
     }
 
-    handleGetSomething(something) {
+    handleGetSomething(state, {body: something}) {
       this.setState({ something });
     }
   }


### PR DESCRIPTION
This adds a new behavior, which allows us to use pure functions as store handlers.

Store handlers receive the store's state now as last argument. When passing in a function which accepts 2 arguments, it will receive the action's payload as first and the store's state as second argument.

When accepting three arguments, it will receive the payload's body as first, the payload itself as second and the store's state as third argument.

Instead of having to call `this.setState`, we can now return an object representing our desired state, and flummox will automatically set the state for us, e.g.:

```
({body}, prevState) => )({
  prop: prevState.prop.concat(body)
});
```