### PR TITLE
Replaced React.addons.cloneWithProps with React.cloneElement

### DIFF
--- a/src/addons/FluxComponent.js
+++ b/src/addons/FluxComponent.js
@@ -67,7 +67,7 @@ export default (React, PlainWrapperComponent) => {
     }
 
     wrapChild = (child) => {
-      return React.addons.cloneWithProps(
+      return React.cloneElement(
         child,
         assign(
           this.getExtraProps(),

--- a/src/addons/react.js
+++ b/src/addons/react.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 
 import createFluxComponent from './FluxComponent';
 import createConnect from './connect';


### PR DESCRIPTION
Replaced `React.addons.cloneWithProps` with `React.cloneElement` as the former [is deprecated](https://facebook.github.io/react/docs/clone-with-props.html).

This also removes the need for us to import `react/addons`.