### PR TITLE
Fix overwritten store state

### DIFF
--- a/src/addons/reactComponentMethods.js
+++ b/src/addons/reactComponentMethods.js
@@ -255,7 +255,7 @@ function createStoreListener(component, store, storeStateGetter) {
   return function() {
     const state = storeStateGetter(store, this.props);
     this.setState({
-      storeState: state
+      storeState: assign(this.state.storeState, state)
     });
   }.bind(component);
 }


### PR DESCRIPTION
I previously merged in a PR which broke other tests. Revered that. New PR with test case for the broken behavior. Breaks the `fluxMixin ignores change event after unmounted` test though.

@acdlite What do you think we should do here? Get rid of the failing test? It ouputs `Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.` as a warning anyway. If it's a no-op, it wouldn't be too bad? Sadly we cannot use `isMounted`, because it's simply not available on es6 classes.
