### PR TITLE
update docs

### DIFF
--- a/docs/docs/api/actions.md
+++ b/docs/docs/api/actions.md
@@ -62,7 +62,7 @@ expect(actions.createMessage('Hello world!')).to.eventually.deep.equal({
 Asynchronous actions
 --------------------
 
-Asynchronous actions are actions that return promises. Unlike synchronous actions, async actions fire the dispatcher twice: at the beginning and at the end of the action. Refer to the [Store API](store.md) for information on how to register handlers for asynchronous actions.
+Asynchronous actions are actions that return promises. Unlike synchronous actions, async actions may fire the dispatcher up to three times: at the beginning and end of the action, or upon failure. Refer to the [Store API](store.md) for information on how to register handlers for asynchronous actions.
 
 Methods
 -------


### PR DESCRIPTION
I felt that this section was a little inaccurate about async actions (the behavior has likely changed since it was written).

`null` can be passed as a handler to `registerAsync`, and it also takes a failure handler, so I modified the section to reflect that.